### PR TITLE
Adopt Standard

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,0 +1,51 @@
+# Auto generated files with errors to ignore.
+# Remove from this list as you refactor files.
+---
+ignore:
+- example/e-paper_spi/epd2in13b.rb:
+  - Style/MixinUsage
+- example/loopback/spi.rb:
+  - Style/MixinUsage
+  - Lint/UselessAssignment
+- example/loopback/uart.rb:
+  - Style/MixinUsage
+  - Lint/UselessAssignment
+- example/sharp_memory_display/ls013b7dn05.rb:
+  - Lint/UselessAssignment
+  - Style/SafeNavigation
+  - Style/MixinUsage
+- example/simple/callback.rb:
+  - Style/MixinUsage
+- example/simple/led.rb:
+  - Style/MixinUsage
+- example/simple/pwm.rb:
+  - Style/MixinUsage
+  - Style/InfiniteLoop
+- example/simple/wave.rb:
+  - Style/MixinUsage
+- example/ssd1306_i2c/ssd1306.rb:
+  - Style/MixinUsage
+- lib/pigpio.rb:
+  - Naming/VariableName
+- lib/pigpio/bank.rb:
+  - Naming/ConstantName
+- lib/pigpio/constant.rb:
+  - Naming/ConstantName
+- lib/pigpio/gpio.rb:
+  - Lint/UselessAssignment
+  - Naming/VariableName
+- lib/pigpio/i2c.rb:
+  - Naming/VariableName
+- lib/pigpio/pwm.rb:
+  - Lint/UselessAssignment
+- lib/pigpio/serial.rb:
+  - Naming/ConstantName
+  - Lint/UselessAssignment
+  - Naming/VariableName
+- lib/pigpio/spi.rb:
+  - Naming/VariableName
+- lib/pigpio/user_gpio.rb:
+  - Lint/UselessAssignment
+  - Naming/VariableName
+- spec/ext/extconf.rb:
+  - Style/GlobalVars

--- a/Rakefile
+++ b/Rakefile
@@ -9,10 +9,9 @@ end
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
 
-
-RDOC_FILES = FileList["ext/pigpio/pigpio.c","lib/**/*.rb"]
+RDOC_FILES = FileList["ext/pigpio/pigpio.c", "lib/**/*.rb"]
 
 Rake::RDocTask.new do |rd|
   rd.main = "pigpio.c"

--- a/example/e-paper_spi/epd2in13b.rb
+++ b/example/e-paper_spi/epd2in13b.rb
@@ -2,17 +2,17 @@ require "pigpio"
 require "rmagick"
 
 class EPD2IN13B
-  attr_reader :width,:height,:buf_red,:buf_black
-  def initialize(spi,rst,dc,busy,cs,width=104,height=212)
-    @width=width
-    @height=height
-    @spi=spi
-    @rst=rst
-    @dc=dc
-    @cs=cs
-    @busy=busy
-    @buf_black=Array.new((@width/8)*height,0)
-    @buf_red=Array.new((@width/8)*height,0)
+  attr_reader :width, :height, :buf_red, :buf_black
+  def initialize(spi, rst, dc, busy, cs, width = 104, height = 212)
+    @width = width
+    @height = height
+    @spi = spi
+    @rst = rst
+    @dc = dc
+    @cs = cs
+    @busy = busy
+    @buf_black = Array.new((@width / 8) * height, 0)
+    @buf_red = Array.new((@width / 8) * height, 0)
     @rst.mode = PI_OUTPUT
     @rst.pud = PI_PUD_OFF
     @rst.write 1
@@ -33,51 +33,51 @@ class EPD2IN13B
     sleep 0.2
     @rst.write 1
 
-    com(BOOSTER_SOFT_START,0x17,0x17,0x17)
+    com(BOOSTER_SOFT_START, 0x17, 0x17, 0x17)
     com(POWER_ON)
     wait_busy
-    com(PANEL_SETTING,0x8F)
-    com(VCOM_AND_DATA_INTERVAL_SETTING,0xF0)
-    com(RESOLUTION_SETTING,@width & 0xff,@height >> 8,@height & 0xff)
+    com(PANEL_SETTING, 0x8F)
+    com(VCOM_AND_DATA_INTERVAL_SETTING, 0xF0)
+    com(RESOLUTION_SETTING, @width & 0xff, @height >> 8, @height & 0xff)
   end
 
   def display
-    com(DATA_START_TRANSMISSION_1,*@buf_black)
+    com(DATA_START_TRANSMISSION_1, *@buf_black)
     com(DATA_STOP)
-    
-    com(DATA_START_TRANSMISSION_2,*@buf_red)
+
+    com(DATA_START_TRANSMISSION_2, *@buf_red)
     com(DATA_STOP)
-    
-    com(DISPLAY_REFRESH) 
+
+    com(DISPLAY_REFRESH)
     wait_busy
   end
 
   def wait_busy
-    sleep 0.1 while(@busy.read == 0)
+    sleep 0.1 while @busy.read == 0
   end
 
-  def com(command,*arg)
+  def com(command, *arg)
     @cs.write 0
 
-    @dc.write 0 #command
+    @dc.write 0 # command
     @spi.write [command].pack("c*")
 
-    @dc.write 1 #data
+    @dc.write 1 # data
     @spi.write arg.pack("c*") if arg.size > 0
 
     @cs.write 1
   end
 
   def image2buf(image)
-    @buf_black=[]
-    @buf_red=[]
-    th=65536/2
-    (@height).times do |y|
-      (@width/8).times do |col|
-        black,red=8.times.with_object([0,0]) do |x,c|
-          px= image.pixel_color(x+col*8,y)
-          c[0]=c[0]<<1 | (px.red <  th && px.green < th ? 0 : 1)
-          c[1]=c[1]<<1 | (px.red >= th && px.green < th ? 0 : 1)
+    @buf_black = []
+    @buf_red = []
+    th = 65536 / 2
+    @height.times do |y|
+      (@width / 8).times do |col|
+        black, red = 8.times.with_object([0, 0]) do |x, c|
+          px = image.pixel_color(x + col * 8, y)
+          c[0] = c[0] << 1 | (px.red < th && px.green < th ? 0 : 1)
+          c[1] = c[1] << 1 | (px.red >= th && px.green < th ? 0 : 1)
         end
         @buf_black.push black
         @buf_red.push red
@@ -86,94 +86,93 @@ class EPD2IN13B
   end
 
   # Display resolution
-  EPD_WIDTH       = 104
-  EPD_HEIGHT      = 212
+  EPD_WIDTH = 104
+  EPD_HEIGHT = 212
 
   # EPD2IN13B commands
-  PANEL_SETTING                               = 0x00
-  POWER_SETTING                               = 0x01
-  POWER_OFF                                   = 0x02
-  POWER_OFF_SEQUENCE_SETTING                  = 0x03
-  POWER_ON                                    = 0x04
-  POWER_ON_MEASURE                            = 0x05
-  BOOSTER_SOFT_START                          = 0x06
-  DEEP_SLEEP                                  = 0x07
-  DATA_START_TRANSMISSION_1                   = 0x10
-  DATA_STOP                                   = 0x11
-  DISPLAY_REFRESH                             = 0x12
-  DATA_START_TRANSMISSION_2                   = 0x13
-  VCOM_LUT                                    = 0x20
-  W2W_LUT                                     = 0x21
-  B2W_LUT                                     = 0x22
-  W2B_LUT                                     = 0x23
-  B2B_LUT                                     = 0x24
-  PLL_CONTROL                                 = 0x30
-  TEMPERATURE_SENSOR_CALIBRATION              = 0x40
-  TEMPERATURE_SENSOR_SELECTION                = 0x41
-  TEMPERATURE_SENSOR_WRITE                    = 0x42
-  TEMPERATURE_SENSOR_READ                     = 0x43
-  VCOM_AND_DATA_INTERVAL_SETTING              = 0x50
-  LOW_POWER_DETECTION                         = 0x51
-  TCON_SETTING                                = 0x60
-  RESOLUTION_SETTING                          = 0x61
-  GET_STATUS                                  = 0x71
-  AUTO_MEASURE_VCOM                           = 0x80
-  VCOM_VALUE                                  = 0x81
-  VCM_DC_SETTING                              = 0x82
-  PARTIAL_WINDOW                              = 0x90
-  PARTIAL_IN                                  = 0x91
-  PARTIAL_OUT                                 = 0x92
-  PROGRAM_MODE                                = 0xA0
-  ACTIVE_PROGRAM                              = 0xA1
-  READ_OTP_DATA                               = 0xA2
-  POWER_SAVING                                = 0xE3
-
+  PANEL_SETTING = 0x00
+  POWER_SETTING = 0x01
+  POWER_OFF = 0x02
+  POWER_OFF_SEQUENCE_SETTING = 0x03
+  POWER_ON = 0x04
+  POWER_ON_MEASURE = 0x05
+  BOOSTER_SOFT_START = 0x06
+  DEEP_SLEEP = 0x07
+  DATA_START_TRANSMISSION_1 = 0x10
+  DATA_STOP = 0x11
+  DISPLAY_REFRESH = 0x12
+  DATA_START_TRANSMISSION_2 = 0x13
+  VCOM_LUT = 0x20
+  W2W_LUT = 0x21
+  B2W_LUT = 0x22
+  W2B_LUT = 0x23
+  B2B_LUT = 0x24
+  PLL_CONTROL = 0x30
+  TEMPERATURE_SENSOR_CALIBRATION = 0x40
+  TEMPERATURE_SENSOR_SELECTION = 0x41
+  TEMPERATURE_SENSOR_WRITE = 0x42
+  TEMPERATURE_SENSOR_READ = 0x43
+  VCOM_AND_DATA_INTERVAL_SETTING = 0x50
+  LOW_POWER_DETECTION = 0x51
+  TCON_SETTING = 0x60
+  RESOLUTION_SETTING = 0x61
+  GET_STATUS = 0x71
+  AUTO_MEASURE_VCOM = 0x80
+  VCOM_VALUE = 0x81
+  VCM_DC_SETTING = 0x82
+  PARTIAL_WINDOW = 0x90
+  PARTIAL_IN = 0x91
+  PARTIAL_OUT = 0x92
+  PROGRAM_MODE = 0xA0
+  ACTIVE_PROGRAM = 0xA1
+  READ_OTP_DATA = 0xA2
+  POWER_SAVING = 0xE3
 end
 
-def word_wrap(draw,str,width)
+def word_wrap(draw, str, width)
   str.each_line.map do |v|
-    v.chomp.size.times.with_object([0]) do |i,ins|
+    v.chomp.size.times.with_object([0]) do |i, ins|
       ins.unshift(i) if draw.get_type_metrics(v[ins.first..i]).width > width
-    end[0..-2].each{|i|v.insert(i,"\n")}
+    end[0..-2].each { |i| v.insert(i, "\n") }
     v
   end.join("")
 end
 
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
   p "error" + pi.pi.to_s
-  exit -1
+  exit(-1)
 end
 
-rst=pi.gpio(17)
-dc=pi.gpio(25)
-busy=pi.gpio(24)
-cs=pi.gpio(8)
+rst = pi.gpio(17)
+dc = pi.gpio(25)
+busy = pi.gpio(24)
+cs = pi.gpio(8)
 
-spi=pi.spi(0)
+spi = pi.spi(0)
 if spi.handle < 0
   p "spi error" + spi.handle.to_s
   pi.stop
-  exit -2
+  exit(-2)
 end
 
 begin
-  d=EPD2IN13B.new(spi,rst,dc,busy,cs)
+  d = EPD2IN13B.new(spi, rst, dc, busy, cs)
   d.reset
 
-  image = Magick::Image.new(d.width, d.height){
-    self.background_color="white"
+  image = Magick::Image.new(d.width, d.height) {
+    self.background_color = "white"
   }
   draw = Magick::Draw.new
-  draw.font = '../font/misaki_gothic.ttf' # Little Limit (http://littlelimit.net/)
+  draw.font = "../font/misaki_gothic.ttf" # Little Limit (http://littlelimit.net/)
   draw.pointsize = 8
-  draw.fill = 'black'
+  draw.fill = "black"
   draw.gravity = Magick::NorthWestGravity
-  str = word_wrap(draw,DATA.read,d.width)
+  str = word_wrap(draw, DATA.read, d.width)
   draw.annotate(image, 0, 0, 0, 0, str)
-  draw.fill = 'red'
-  draw.annotate(image, 0, 0, 0, str.lines.size*8, str)
+  draw.fill = "red"
+  draw.annotate(image, 0, 0, 0, str.lines.size * 8, str)
 
   d.image2buf(image)
   d.display

--- a/example/loopback/spi.rb
+++ b/example/loopback/spi.rb
@@ -1,24 +1,24 @@
 require "pigpio"
 
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
-counter=0
-cs=pi.gpio(8)
-cs.mode=PI_OUTPUT
-cs.pud=PI_PUD_OFF
-mosi=pi.gpio(10)
-mosi.mode=PI_OUTPUT
-mosi.pud=PI_PUD_OFF
-clk=pi.gpio(11)
-clk.mode=PI_OUTPUT
-clk.pud=PI_PUD_OFF
-miso=pi.gpio(9)
-miso.mode=PI_INPUT
-miso.pud=PI_PUD_OFF
-spi=pi.spi()
+counter = 0
+cs = pi.gpio(8)
+cs.mode = PI_OUTPUT
+cs.pud = PI_PUD_OFF
+mosi = pi.gpio(10)
+mosi.mode = PI_OUTPUT
+mosi.pud = PI_PUD_OFF
+clk = pi.gpio(11)
+clk.mode = PI_OUTPUT
+clk.pud = PI_PUD_OFF
+miso = pi.gpio(9)
+miso.mode = PI_INPUT
+miso.pud = PI_PUD_OFF
+spi = pi.spi()
 p spi.xfer "abcdef"
 spi.close
 pi.stop

--- a/example/loopback/uart.rb
+++ b/example/loopback/uart.rb
@@ -1,24 +1,24 @@
 require "pigpio"
 
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
-counter=0
-tx=pi.gpio(27)
-tx.mode=PI_OUTPUT
-tx.pud=PI_PUD_OFF
+counter = 0
+tx = pi.gpio(27)
+tx.mode = PI_OUTPUT
+tx.pud = PI_PUD_OFF
 
-rx=pi.gpio(22)
-rx.mode=PI_INPUT
-rx.pud=PI_PUD_OFF
+rx = pi.gpio(22)
+rx.mode = PI_INPUT
+rx.pud = PI_PUD_OFF
 
-uart=pi.serial(rx,tx)
+uart = pi.serial(rx, tx)
 uart.write_sync "abc"
 uart.write_sync "def"
 p uart.read(10)
 uart.write_sync "zyx"
-4.times{p uart.read(1)}
+4.times { p uart.read(1) }
 uart.close
 pi.stop

--- a/example/sharp_memory_display/ls013b7dn05.rb
+++ b/example/sharp_memory_display/ls013b7dn05.rb
@@ -2,30 +2,30 @@ require "pigpio"
 require "rmagick"
 
 class SharpMemoryDisplay
-    attr_reader :width,:height,:buf
-  CMD_BIT_WRITECMD   =(0x80)
-  CMD_BIT_VCOM       =(0x40)
-  CMD_BIT_CLEAR      =(0x20)
-  DUMMY_DATA         =0x00
+  attr_reader :width, :height, :buf
+  CMD_BIT_WRITECMD = 0x80
+  CMD_BIT_VCOM = 0x40
+  CMD_BIT_CLEAR = 0x20
+  DUMMY_DATA = 0x00
 
-  BitRverseChar= 256.times.map do |v|
-    8.times.inject(0){|ret,i| ret |= (v & 0x01<<i)!=0 ? 0x80>>i : 0}
+  BitRverseChar = 256.times.map do |v|
+    8.times.inject(0) { |ret, i| ret |= (v & 0x01 << i) != 0 ? 0x80 >> i : 0 }
   end
 
-  def initialize(spi,com,cs,width,height)
-    @width=width
-    @height=height
-    @spi=spi
-    @com=com
-    @cs=cs
-    @buf=Array.new((@width/8)*height,0)
+  def initialize(spi, com, cs, width, height)
+    @width = width
+    @height = height
+    @spi = spi
+    @com = com
+    @cs = cs
+    @buf = Array.new((@width / 8) * height, 0)
     @com.mode = PI_OUTPUT
     @com.pud = PI_PUD_OFF
     @com.write 0
     @cs.mode = PI_OUTPUT
     @cs.pud = PI_PUD_OFF
     @cs.write 0
-    @wave=generate_com @com
+    @wave = generate_com @com
   end
 
   def stop
@@ -34,12 +34,12 @@ class SharpMemoryDisplay
     @com.write 0
   end
 
-  def display(num=0)
+  def display(num = 0)
     com(*@buf)
   end
 
   def clear
-    com(CMD_BIT_CLEAR,DUMMY_DATA)
+    com(CMD_BIT_CLEAR, DUMMY_DATA)
   end
 
   def com(*data)
@@ -50,26 +50,26 @@ class SharpMemoryDisplay
 
   def generate_com pin
     mark = 0x01 << pin.gpio
-    wave=Pigpio::Wave.new(pin.pi)
+    wave = Pigpio::Wave.new(pin.pi)
     wave.add_new
     wave.add_generic([
-      wave.pulse(mark,0x00,3),
-      wave.pulse(0x00,mark,1000000-10000),
+      wave.pulse(mark, 0x00, 3),
+      wave.pulse(0x00, mark, 1000000 - 10000)
     ])
-    wid=wave.create
-    wave.chain([255,0,wid,255,3])
+    wid = wave.create
+    wave.chain([255, 0, wid, 255, 3])
     wave
   end
 
   def image2buf(image)
-    @buf=[CMD_BIT_WRITECMD]
-    th=65536/2
-    (@height).times do |y|
-      @buf.push BitRverseChar[y+1]
-      (@width/8).times do |col|
-        ret=8.times.inject(0) do |c,x|
-          px= image.pixel_color(x+col*8,y)
-          c<<1 | (px.red < th ? 0 : 1)
+    @buf = [CMD_BIT_WRITECMD]
+    th = 65536 / 2
+    @height.times do |y|
+      @buf.push BitRverseChar[y + 1]
+      (@width / 8).times do |col|
+        ret = 8.times.inject(0) do |c, x|
+          px = image.pixel_color(x + col * 8, y)
+          c << 1 | (px.red < th ? 0 : 1)
         end
         @buf.push ret
       end
@@ -80,67 +80,66 @@ class SharpMemoryDisplay
 end
 
 class LS013B4DN04 < SharpMemoryDisplay
-  def initialize(spi,com,cs,width=96,height=96)
+  def initialize(spi, com, cs, width = 96, height = 96)
     super
   end
 end
 
 class LS013B7DH05 < SharpMemoryDisplay
-  def initialize(spi,com,cs,width=144,height=168)
+  def initialize(spi, com, cs, width = 144, height = 168)
     super
   end
 end
 
 class LS027B4DH01 < SharpMemoryDisplay
-  def initialize(spi,com,cs,width=400,height=240)
+  def initialize(spi, com, cs, width = 400, height = 240)
     super
   end
 end
 
-def word_wrap(draw,str,width)
+def word_wrap(draw, str, width)
   str.each_line.map do |v|
-    v.chomp.size.times.with_object([0]) do |i,ins|
+    v.chomp.size.times.with_object([0]) do |i, ins|
       ins.unshift(i) if draw.get_type_metrics(v[ins.first..i]).width > width
-    end[0..-2].each{|i|v.insert(i,"\n")}
+    end[0..-2].each { |i| v.insert(i, "\n") }
     v
   end.join("")
 end
 
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
   p "error" + pi.pi.to_s
-  exit -1
+  exit(-1)
 end
 
-com=pi.gpio(17)
-cs=pi.gpio(22)
+com = pi.gpio(17)
+cs = pi.gpio(22)
 
-spi=pi.spi(0)
+spi = pi.spi(0)
 if spi.handle < 0
   p "spi error" + spi.handle.to_s
   pi.stop
-  exit -2
+  exit(-2)
 end
 
 begin
-  d=LS013B7DH05.new(spi,com,cs)
+  d = LS013B7DH05.new(spi, com, cs)
 
-  image = Magick::Image.new(d.width, d.height){
-    self.background_color="white"
+  image = Magick::Image.new(d.width, d.height) {
+    self.background_color = "white"
   }
   draw = Magick::Draw.new
-  draw.font = './example/font/misaki_gothic.ttf' # Little Limit (http://littlelimit.net/)
+  draw.font = "./example/font/misaki_gothic.ttf" # Little Limit (http://littlelimit.net/)
   draw.pointsize = 8
-  draw.fill = 'black'
+  draw.fill = "black"
   draw.gravity = Magick::NorthWestGravity
-  str = word_wrap(draw,DATA.read,d.width)
+  str = word_wrap(draw, DATA.read, d.width)
   draw.annotate(image, 0, 0, 0, 0, str)
 
   d.image2buf(image)
   d.clear
   d.display
-
 rescue => e
   puts e.full_message
 ensure

--- a/example/simple/callback.rb
+++ b/example/simple/callback.rb
@@ -1,25 +1,25 @@
 require "pigpio"
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
-counter=0
-led=pi.gpio(4)
-led.mode=PI_OUTPUT
-led.pud=PI_PUD_OFF
+counter = 0
+led = pi.gpio(4)
+led.mode = PI_OUTPUT
+led.pud = PI_PUD_OFF
 
-button=pi.gpio(17)
-button.mode=PI_INPUT
-button.pud=PI_PUD_UP
+button = pi.gpio(17)
+button.mode = PI_INPUT
+button.pud = PI_PUD_UP
 button.glitch_filter(30)
-cb=button.callback(EITHER_EDGE){|tick,level|
+cb = button.callback(EITHER_EDGE) { |tick, level|
   led.write level
-  counter+=1
+  counter += 1
 }
 
 led.write 1
-while(counter<10)do
+while counter < 10
   sleep(1)
 end
 cb.cancel

--- a/example/simple/led.rb
+++ b/example/simple/led.rb
@@ -1,9 +1,9 @@
 require "pigpio"
 include Pigpio::Constant
 
-pi=Pigpio.new
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
 
 led = pi.gpio(4)

--- a/example/simple/pwm.rb
+++ b/example/simple/pwm.rb
@@ -1,22 +1,22 @@
 require "pigpio"
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
-pin=pi.gpio(4)
-pin.mode=PI_OUTPUT
-pin.pud=PI_PUD_OFF
-pwm=pin.pwm
+pin = pi.gpio(4)
+pin.mode = PI_OUTPUT
+pin.pud = PI_PUD_OFF
+pwm = pin.pwm
 
-button=pi.gpio(17)
-button.mode=PI_INPUT
-button.pud=PI_PUD_UP
+button = pi.gpio(17)
+button.mode = PI_INPUT
+button.pud = PI_PUD_UP
 
-i=128
-while true do
-  i=(i+1)%256   if button.read == 0
-  pwm.dutycycle= i
+i = 128
+while true
+  i = (i + 1) % 256 if button.read == 0
+  pwm.dutycycle = i
   sleep 0.01
 end
 pi.stop

--- a/example/simple/wave.rb
+++ b/example/simple/wave.rb
@@ -1,22 +1,22 @@
 require "pigpio"
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
-  exit -1
+  exit(-1)
 end
 
-led=pi.gpio(4)
-led.mode=PI_OUTPUT
-led.pud=PI_PUD_OFF
+led = pi.gpio(4)
+led.mode = PI_OUTPUT
+led.pud = PI_PUD_OFF
 
-wave=pi.wave
+wave = pi.wave
 wave.add_new
 wave.add_generic([
-  wave.pulse(0x10,0x00,1000000),
-  wave.pulse(0x00,0x10,1000000),
+  wave.pulse(0x10, 0x00, 1000000),
+  wave.pulse(0x00, 0x10, 1000000)
 ])
-wid=wave.create
-wave.chain([255,0,wid,255,1,3,0])
+wid = wave.create
+wave.chain([255, 0, wid, 255, 1, 3, 0])
 while wave.tx_busy
   sleep 0.1
 end

--- a/example/ssd1306_i2c/ssd1306.rb
+++ b/example/ssd1306_i2c/ssd1306.rb
@@ -2,23 +2,23 @@ require "pigpio"
 require "rmagick"
 
 class SSD1306
-  attr_reader :width,:height,:buf
+  attr_reader :width, :height, :buf
   def initialize(i2c)
-    @width=128
-    @height=64
-    @pages=(@height/8)
-    @i2c=i2c
-    @buf=Array.new(@width*@pages,0)
+    @width = 128
+    @height = 64
+    @pages = (@height / 8)
+    @i2c = i2c
+    @buf = Array.new(@width * @pages, 0)
   end
 
   def image2buf(image)
-    @buf=[]
-    (@height/8).times do |row|
+    @buf = []
+    (@height / 8).times do |row|
       @width.times do |x|
-        c=0
+        c = 0
         8.times do |y|
-          px= image.pixel_color(x, y+row*8)
-          c|=(px.red / (65536/2)) << y
+          px = image.pixel_color(x, y + row * 8)
+          c |= (px.red / (65536 / 2)) << y
         end
         @buf.push c
       end
@@ -28,28 +28,28 @@ class SSD1306
 
   def reset
     com(DISPLAYOFF)
-    com(SETDISPLAYCLOCKDIV,0x80)
-    com(SETMULTIPLEX,0x3F)
-    com(SETDISPLAYOFFSET,0x0)   
-    com(SETSTARTLINE | 0x0)     
-    com(CHARGEPUMP,0x14)
-    com(MEMORYMODE,0x00)        
+    com(SETDISPLAYCLOCKDIV, 0x80)
+    com(SETMULTIPLEX, 0x3F)
+    com(SETDISPLAYOFFSET, 0x0)
+    com(SETSTARTLINE | 0x0)
+    com(CHARGEPUMP, 0x14)
+    com(MEMORYMODE, 0x00)
     com(SEGREMAP | 0x1)
     com(COMSCANDEC)
-    com(SETCOMPINS,0x12)
-    com(SETCONTRAST,0xCF)
-    com(SETPRECHARGE,0xF1)
-    com(SETVCOMDETECT,0x40)
-    com(DISPLAYALLON_RESUME)    
-    com(NORMALDISPLAY)          
+    com(SETCOMPINS, 0x12)
+    com(SETCONTRAST, 0xCF)
+    com(SETPRECHARGE, 0xF1)
+    com(SETVCOMDETECT, 0x40)
+    com(DISPLAYALLON_RESUME)
+    com(NORMALDISPLAY)
     com(DISPLAYON)
   end
 
   def display
-    com(COLUMNADDR,0,@width-1)   # Column end address.
-    com(PAGEADDR,0,@pages-1)  # Page end address.(height/8)
-    control = 0x40   # Co = 0, DC = 0
-    @buf.each_slice(32){|b| 
+    com(COLUMNADDR, 0, @width - 1) # Column end address.
+    com(PAGEADDR, 0, @pages - 1) # Page end address.(height/8)
+    control = 0x40 # Co = 0, DC = 0
+    @buf.each_slice(32) { |b|
       @i2c.write_i2c_block_data(control, b.pack("c*"))
     }
   end
@@ -59,7 +59,7 @@ class SSD1306
     @i2c.write_i2c_block_data(control, c.pack("c*"))
   end
 
-  I2C_ADDRESS = 0x3C    # 011110+SA0+RW - 0x3C or 0x3D
+  I2C_ADDRESS = 0x3C # 011110+SA0+RW - 0x3C or 0x3D
   SETCONTRAST = 0x81
   DISPLAYALLON_RESUME = 0xA4
   DISPLAYALLON = 0xA5
@@ -87,44 +87,43 @@ class SSD1306
   SWITCHCAPVCC = 0x2
 end
 
-def word_wrap(draw,str,width)
+def word_wrap(draw, str, width)
   str.each_line.map do |v|
-    v.chomp.size.times.with_object([0]) do |i,ins|
+    v.chomp.size.times.with_object([0]) do |i, ins|
       ins.unshift(i) if draw.get_type_metrics(v[ins.first..i]).width > width
-    end[0..-2].each{|i|v.insert(i,"\n")}
+    end[0..-2].each { |i| v.insert(i, "\n") }
     v
   end.join("")
 end
 
 include Pigpio::Constant
-pi=Pigpio.new()
+pi = Pigpio.new
 unless pi.connect
   p "error" + pi.pi.to_s
-  exit -1
+  exit(-1)
 end
 
-
-i2c=pi.i2c(1,0x3c)
+i2c = pi.i2c(1, 0x3c)
 if i2c.handle < 0
   p "i2c error" + i2c.handle.to_s
   pi.stop
-  exit -2
+  exit(-2)
 end
 
 begin
-  d=SSD1306.new(i2c)
+  d = SSD1306.new(i2c)
   d.reset
 
-  image = Magick::Image.new(d.width, d.height){
-    self.background_color="black"
+  image = Magick::Image.new(d.width, d.height) {
+    self.background_color = "black"
   }
   draw = Magick::Draw.new
-  draw.font = '../font/misaki_gothic.ttf' # Little Limit (http://littlelimit.net/)
+  draw.font = "../font/misaki_gothic.ttf" # Little Limit (http://littlelimit.net/)
   draw.pointsize = 8
-  draw.fill = 'white'
+  draw.fill = "white"
   draw.gravity = Magick::NorthWestGravity
   str = DATA.read
-  draw.annotate(image, 0, 0, 0, 0, word_wrap(draw,str,d.width))
+  draw.annotate(image, 0, 0, 0, 0, word_wrap(draw, str, d.width))
 
   d.image2buf(image)
   d.display

--- a/ext/pigpio/extconf.rb
+++ b/ext/pigpio/extconf.rb
@@ -1,5 +1,5 @@
-require 'mkmf'
-dir_config('pigpio')
-if find_header('pigpiod_if2.h','/usr/include/') && find_library('pigpiod_if2','gpio_read','/usr/lib/')
-  create_makefile('pigpio/pigpio')
+require "mkmf"
+dir_config("pigpio")
+if find_header("pigpiod_if2.h", "/usr/include/") && find_library("pigpiod_if2", "gpio_read", "/usr/lib/")
+  create_makefile("pigpio/pigpio")
 end

--- a/lib/pigpio.rb
+++ b/lib/pigpio.rb
@@ -16,49 +16,59 @@ require "pigpio/i2c"
 
 class Pigpio
   attr_reader :pi
-  def initialize(addr=nil,port=nil,&blk)
-    @pi=IF.pigpio_start(addr,port)
+  def initialize(addr = nil, port = nil, &blk)
+    @pi = IF.pigpio_start(addr, port)
     if blk && connect
-      blk.call(self) 
+      blk.call(self)
       IF.pigpio_stop(@pi)
     end
   end
+
   def connect
-    @pi>=0
+    @pi >= 0
   end
+
   def stop
     IF.pigpio_stop(@pi)
-    @pi=-1
+    @pi = -1
   end
+
   def current_tick
     IF.get_current_tick(@pi)
   end
+
   def hardware_revision
     IF.get_hardware_revision(@pi)
   end
+
   def pigpio_version
     IF.get_pigpio_version(@pi)
   end
-  
+
   def bank(num)
-    Bank.new(@pi,num)
+    Bank.new(@pi, num)
   end
+
   def gpio(gpio)
-    (gpio<32 ? UserGPIO : GPIO).new(@pi,gpio)
+    (gpio < 32 ? UserGPIO : GPIO).new(@pi, gpio)
   end
-  def wave()
+
+  def wave
     Wave.new(@pi)
   end
-  def serial(rx,tx=nil,baud=9600,data_bits=8,stop_bits=1,parity_type=:none)
-    return BitBangSerialRx.new(rx,baud,data_bits) if tx==nil
-    return BitBangSerialTx.new(tx,baud,data_bits,stop_bits) if rx==nil
-    return BitBangSerial.new(rx,tx,baud,data_bits,stop_bits)
+
+  def serial(rx, tx = nil, baud = 9600, data_bits = 8, stop_bits = 1, parity_type = :none)
+    return BitBangSerialRx.new(rx, baud, data_bits) if tx.nil?
+    return BitBangSerialTx.new(tx, baud, data_bits, stop_bits) if rx.nil?
+    BitBangSerial.new(rx, tx, baud, data_bits, stop_bits)
   end
-  def spi(spi_channel=0,enable_cex=1,baud=500000,
-    bits_per_word: 8,first_MISO: false,first_MOSI: false,idol_bytes: 0,is_3wire: false,active_low_cex: 0,spi_mode: 0)
-    SPI.new(@pi,spi_channel,enable_cex,baud,bits_per_word: bits_per_word,first_MISO:first_MISO,first_MOSI:first_MOSI,idol_bytes:idol_bytes,is_3wire:is_3wire,active_low_cex:active_low_cex,spi_mode:spi_mode)
+
+  def spi(spi_channel = 0, enable_cex = 1, baud = 500000,
+    bits_per_word: 8, first_MISO: false, first_MOSI: false, idol_bytes: 0, is_3wire: false, active_low_cex: 0, spi_mode: 0)
+    SPI.new(@pi, spi_channel, enable_cex, baud, bits_per_word: bits_per_word, first_MISO: first_MISO, first_MOSI: first_MOSI, idol_bytes: idol_bytes, is_3wire: is_3wire, active_low_cex: active_low_cex, spi_mode: spi_mode)
   end
-  def i2c(i2c_bus,i2c_addr)
-    I2C.new(@pi,i2c_bus,i2c_addr)
+
+  def i2c(i2c_bus, i2c_addr)
+    I2C.new(@pi, i2c_bus, i2c_addr)
   end
 end

--- a/lib/pigpio/bank.rb
+++ b/lib/pigpio/bank.rb
@@ -1,22 +1,25 @@
 class Pigpio
   class Bank
-    Set={
-      read:  [:read_bank_1 ,:read_bank_2],
-      clear: [:clear_bank_1,:clear_bank_2],
-      set:   [:set_bank_1  ,:set_bank_2],
+    Set = {
+      read: [:read_bank_1, :read_bank_2],
+      clear: [:clear_bank_1, :clear_bank_2],
+      set: [:set_bank_1, :set_bank_2]
     }
-    def initialize(pi,num)
-      @pi=pi
-      @num=num
+    def initialize(pi, num)
+      @pi = pi
+      @num = num
     end
+
     def read
-      IF.send(Set[:read][@num],@pi)
+      IF.send(Set[:read][@num], @pi)
     end
+
     def clear(bits)
-      IF.send(Set[:clear][@num],@pi,bits)
+      IF.send(Set[:clear][@num], @pi, bits)
     end
+
     def set(bits)
-      IF.send(Set[:set][@num],@pi,bits)
+      IF.send(Set[:set][@num], @pi, bits)
     end
   end
 end

--- a/lib/pigpio/bit_bang_serial.rb
+++ b/lib/pigpio/bit_bang_serial.rb
@@ -4,15 +4,17 @@ require_relative "./bit_bang_serial_tx"
 class Pigpio
   class BitBangSerial < BitBangSerialTx
     attr_reader :rx
-    def initialize(rx,tx,baud=9600,data_bits=8,stop_bits=1,parity_type=:none)
-      super(tx,baud,data_bits,stop_bits)
-      @rx=BitBangSerialRx.new(rx,baud,data_bits)
+    def initialize(rx, tx, baud = 9600, data_bits = 8, stop_bits = 1, parity_type = :none)
+      super(tx, baud, data_bits, stop_bits)
+      @rx = BitBangSerialRx.new(rx, baud, data_bits)
     end
+
     def close
       super
       @rx.close
     end
-    def read(bufsize=1)
+
+    def read(bufsize = 1)
       @rx.read(bufsize)
     end
   end

--- a/lib/pigpio/bit_bang_serial_rx.rb
+++ b/lib/pigpio/bit_bang_serial_rx.rb
@@ -1,7 +1,6 @@
 class Pigpio
-  # Set a UserGPIO pin as a serial Rx. 
+  # Set a UserGPIO pin as a serial Rx.
   class BitBangSerialRx
-
     # UserGPIO#.
     #
     # This attribute is set at the time of ::new.
@@ -12,7 +11,7 @@ class Pigpio
     # This attribute is set at the time of ::new.
     attr_reader :valid
 
-    # Set a UserGPIO pin as a serial Rx. 
+    # Set a UserGPIO pin as a serial Rx.
     #
     # The serial data recieves in a internal cyclic buffer and is read using #read method.
     # It is the caller's responsibility to read data from the cyclic buffer in a timely fashion.
@@ -23,49 +22,49 @@ class Pigpio
     #  [data_bits [ Integer ]] 1-32 [bit/word]. default 8.
     #
     # See also: {pigpio site}[http://abyz.me.uk/rpi/pigpio/pdif2.html#bb_serial_read_open]
-    def initialize(rx,baud=9600,data_bits=8)
-      @rx=rx
-      @valid=IF.bb_serial_read_open(@rx.pi,@rx.gpio,baud,data_bits)
-      if @valid==0
-        @valid=IF.bb_serial_invert(@rx.pi,@rx.gpio,0)
+    def initialize(rx, baud = 9600, data_bits = 8)
+      @rx = rx
+      @valid = IF.bb_serial_read_open(@rx.pi, @rx.gpio, baud, data_bits)
+      if @valid == 0
+        @valid = IF.bb_serial_invert(@rx.pi, @rx.gpio, 0)
       end
     end
 
     # This method closes a GPIO for bit bang reading of serial data.
-    # 
+    #
     # [Return] [Integer] Returns 0 if OK, otherwise PI_BAD_USER_GPIO, or PI_NOT_SERIAL_GPIO.
-    # 
+    #
     # See also: {pigpio site}[http://abyz.me.uk/rpi/pigpio/pdif2.html#bb_serial_read_close]
     def close
-      IF.bb_serial_read_close(@rx.pi,@rx.gpio)
+      IF.bb_serial_read_close(@rx.pi, @rx.gpio)
     end
 
     # This method copies up to bufSize bytes of data read from the bit bang serial cyclic buffer to the buffer starting at returned value.
-    # 
+    #
     # [Parameter] [bufSize [ Integer ]] How many bytes receive.
     # [Return] [ Pigpio::Buffer ] A copied buffer and status.
-    # 
+    #
     # The details of the returned status is the number of bytes copied if OK, otherwise PI_BAD_USER_GPIO or PI_NOT_SERIAL_GPIO.
-    # 
+    #
     # The bytes returned for each character depend upon the number of data bits +data_bits+ specified in the ::new method.
-    # 
-    # * For +data_bits+ 1-8 there will be one byte per character. 
-    # * For +data_bits+ 9-16 there will be two bytes per character. 
+    #
+    # * For +data_bits+ 1-8 there will be one byte per character.
+    # * For +data_bits+ 9-16 there will be two bytes per character.
     # * For +data_bits+ 17-32 there will be four bytes per character.
-    # 
+    #
     # See also: {pigpio site}[http://abyz.me.uk/rpi/pigpio/pdif2.html#bb_serial_read]
-    def read(bufsize=1)
-      IF.bb_serial_read(@rx.pi,@rx.gpio,bufsize)
+    def read(bufsize = 1)
+      IF.bb_serial_read(@rx.pi, @rx.gpio, bufsize)
     end
 
     # This method inverts serial logic for big bang serial reads.
-    # 
+    #
     # [Parameter] [Integer] invert 0-1.1 invert, 0 normal.
     # [Return] [Integer] Returns 0 if OK, otherwise PI_NOT_SERIAL_GPIO or PI_BAD_SER_INVERT.
-    # 
+    #
     # See also: {pigpio site}[http://abyz.me.uk/rpi/pigpio/pdif2.html#bb_serial_invert]
-    def invert(invert=1)
-      IF.bb_serial_invert(@rx.pi,@rx.gpio,invert)
+    def invert(invert = 1)
+      IF.bb_serial_invert(@rx.pi, @rx.gpio, invert)
     end
   end
 end

--- a/lib/pigpio/bit_bang_serial_tx.rb
+++ b/lib/pigpio/bit_bang_serial_tx.rb
@@ -1,39 +1,45 @@
 class Pigpio
   class BitBangSerialTx
     attr_reader :tx
-    def initialize(tx,baud=9600,data_bits=8,stop_bits=1)
-      @tx=tx
-      @baud=baud
-      @data_bits=data_bits
-      @stop_half_bits=(stop_bits*2).round.to_i
+    def initialize(tx, baud = 9600, data_bits = 8, stop_bits = 1)
+      @tx = tx
+      @baud = baud
+      @data_bits = data_bits
+      @stop_half_bits = (stop_bits * 2).round.to_i
     end
+
     def close
       IF.wave_tx_stop(@tx.pi) if busy?
       IF.wave_clear(@tx.pi)
     end
+
     def write(buf)
       IF.wave_clear(@tx.pi)
       IF.wave_add_new(@tx.pi)
-      ret=IF.wave_add_serial(@tx.pi,@tx.gpio,@baud,@data_bits,@stop_half_bits,0,buf)
+      ret = IF.wave_add_serial(@tx.pi, @tx.gpio, @baud, @data_bits, @stop_half_bits, 0, buf)
       return ret if ret < 0
-      wid=IF.wave_create(@tx.pi)
+      wid = IF.wave_create(@tx.pi)
       return wid if wid < 0
-      IF.wave_send_once(@tx.pi,wid)
+      IF.wave_send_once(@tx.pi, wid)
     end
+
     def sync
       while busy?
         sleep 0.1
       end
     end
+
     def write_sync(buf)
-      ret=write(buf)
+      ret = write(buf)
       return ret if ret < 0
       sync
       IF.wave_clear(@tx.pi)
     end
+
     def busy?
       IF.wave_tx_busy(@tx.pi)
     end
+
     def stop
       IF.wave_tx_stop(@tx.pi)
     end

--- a/lib/pigpio/buffer.rb
+++ b/lib/pigpio/buffer.rb
@@ -1,12 +1,13 @@
 class Pigpio
   class Buffer < String
     attr_reader :ret_code
-    def initialize(ret_code,str=nil)
+    def initialize(ret_code, str = nil)
       super(str)
-      @ret_code=ret_code
+      @ret_code = ret_code
     end
+
     def valid?
-      @ret_code>=0
+      @ret_code >= 0
     end
   end
 end

--- a/lib/pigpio/constant.rb
+++ b/lib/pigpio/constant.rb
@@ -1,748 +1,745 @@
 class Pigpio
   module Constant
-    #/* gpio: 0-53 */
+    # /* gpio: 0-53 */
 
-    PI_MIN_GPIO       =0
-    PI_MAX_GPIO      =53
+    PI_MIN_GPIO = 0
+    PI_MAX_GPIO = 53
 
-    #/* user_gpio: 0-31 */
+    # /* user_gpio: 0-31 */
 
-    PI_MAX_USER_GPIO =31
+    PI_MAX_USER_GPIO = 31
 
-    #/* level: 0-1 */
+    # /* level: 0-1 */
 
-    PI_OFF   =0
-    PI_ON    =1
+    PI_OFF = 0
+    PI_ON = 1
 
-    PI_CLEAR =0
-    PI_SET   =1
+    PI_CLEAR = 0
+    PI_SET = 1
 
-    PI_LOW   =0
-    PI_HIGH  =1
+    PI_LOW = 0
+    PI_HIGH = 1
 
-    #/* level: only reported for GPIO time-out, see gpioSetWatchdog */
+    # /* level: only reported for GPIO time-out, see gpioSetWatchdog */
 
-    PI_TIMEOUT =2
+    PI_TIMEOUT = 2
 
-    #/* mode: 0-7 */
+    # /* mode: 0-7 */
 
-    PI_INPUT  =0
-    PI_OUTPUT =1
-    PI_ALT0   =4
-    PI_ALT1   =5
-    PI_ALT2   =6
-    PI_ALT3   =7
-    PI_ALT4   =3
-    PI_ALT5   =2
+    PI_INPUT = 0
+    PI_OUTPUT = 1
+    PI_ALT0 = 4
+    PI_ALT1 = 5
+    PI_ALT2 = 6
+    PI_ALT3 = 7
+    PI_ALT4 = 3
+    PI_ALT5 = 2
 
-    #/* pud: 0-2 */
+    # /* pud: 0-2 */
 
-    PI_PUD_OFF  =0
-    PI_PUD_DOWN =1
-    PI_PUD_UP   =2
+    PI_PUD_OFF = 0
+    PI_PUD_DOWN = 1
+    PI_PUD_UP = 2
 
-    #/* dutycycle: 0-range */
+    # /* dutycycle: 0-range */
 
-    PI_DEFAULT_DUTYCYCLE_RANGE   =255
+    PI_DEFAULT_DUTYCYCLE_RANGE = 255
 
-    #/* range: 25-40000 */
+    # /* range: 25-40000 */
 
-    PI_MIN_DUTYCYCLE_RANGE        =25
-    PI_MAX_DUTYCYCLE_RANGE     =40000
+    PI_MIN_DUTYCYCLE_RANGE = 25
+    PI_MAX_DUTYCYCLE_RANGE = 40000
 
-    #/* pulsewidth: 0, 500-2500 */
+    # /* pulsewidth: 0, 500-2500 */
 
-    PI_SERVO_OFF =0
-    PI_MIN_SERVO_PULSEWIDTH =500
-    PI_MAX_SERVO_PULSEWIDTH =2500
+    PI_SERVO_OFF = 0
+    PI_MIN_SERVO_PULSEWIDTH = 500
+    PI_MAX_SERVO_PULSEWIDTH = 2500
 
-    #/* hardware PWM */
+    # /* hardware PWM */
 
-    PI_HW_PWM_MIN_FREQ =1
-    PI_HW_PWM_MAX_FREQ =125000000
-    PI_HW_PWM_RANGE =1000000
+    PI_HW_PWM_MIN_FREQ = 1
+    PI_HW_PWM_MAX_FREQ = 125000000
+    PI_HW_PWM_RANGE = 1000000
 
-    #/* hardware clock */
+    # /* hardware clock */
 
-    PI_HW_CLK_MIN_FREQ =4689
-    PI_HW_CLK_MAX_FREQ =250000000
+    PI_HW_CLK_MIN_FREQ = 4689
+    PI_HW_CLK_MAX_FREQ = 250000000
 
-    PI_NOTIFY_SLOTS  =32
+    PI_NOTIFY_SLOTS = 32
 
-    PI_NTFY_FLAGS_EVENT    =(1 <<7)
-    PI_NTFY_FLAGS_ALIVE    =(1 <<6)
-    PI_NTFY_FLAGS_WDOG     =(1 <<5)
-  #  PI_NTFY_FLAGS_BIT(x) =(((x)<<0)&31)
+    PI_NTFY_FLAGS_EVENT = (1 << 7)
+    PI_NTFY_FLAGS_ALIVE = (1 << 6)
+    PI_NTFY_FLAGS_WDOG = (1 << 5)
+    #  PI_NTFY_FLAGS_BIT(x) =(((x)<<0)&31)
 
-    PI_WAVE_BLOCKS     =4
-    PI_WAVE_MAX_PULSES =(PI_WAVE_BLOCKS * 3000)
-    PI_WAVE_MAX_CHARS  =(PI_WAVE_BLOCKS *  300)
+    PI_WAVE_BLOCKS = 4
+    PI_WAVE_MAX_PULSES = (PI_WAVE_BLOCKS * 3000)
+    PI_WAVE_MAX_CHARS = (PI_WAVE_BLOCKS * 300)
 
-    PI_BB_I2C_MIN_BAUD     =50
-    PI_BB_I2C_MAX_BAUD =500000
+    PI_BB_I2C_MIN_BAUD = 50
+    PI_BB_I2C_MAX_BAUD = 500000
 
-    PI_BB_SPI_MIN_BAUD     =50
-    PI_BB_SPI_MAX_BAUD =250000
+    PI_BB_SPI_MIN_BAUD = 50
+    PI_BB_SPI_MAX_BAUD = 250000
 
-    PI_BB_SER_MIN_BAUD     =50
-    PI_BB_SER_MAX_BAUD =250000
+    PI_BB_SER_MIN_BAUD = 50
+    PI_BB_SER_MAX_BAUD = 250000
 
-    PI_BB_SER_NORMAL =0
-    PI_BB_SER_INVERT =1
+    PI_BB_SER_NORMAL = 0
+    PI_BB_SER_INVERT = 1
 
-    PI_WAVE_MIN_BAUD      =50
-    PI_WAVE_MAX_BAUD =1000000
+    PI_WAVE_MIN_BAUD = 50
+    PI_WAVE_MAX_BAUD = 1000000
 
-    PI_SPI_MIN_BAUD     =32000
-    PI_SPI_MAX_BAUD =125000000
+    PI_SPI_MIN_BAUD = 32000
+    PI_SPI_MAX_BAUD = 125000000
 
-    PI_MIN_WAVE_DATABITS =1
-    PI_MAX_WAVE_DATABITS =32
+    PI_MIN_WAVE_DATABITS = 1
+    PI_MAX_WAVE_DATABITS = 32
 
-    PI_MIN_WAVE_HALFSTOPBITS =2
-    PI_MAX_WAVE_HALFSTOPBITS =8
-
-    PI_WAVE_MAX_MICROS =(30 * 60 * 1000000) #/* half an hour */
-
-    PI_MAX_WAVES =250
-
-    PI_MAX_WAVE_CYCLES =65535
-    PI_MAX_WAVE_DELAY  =65535
-
-    PI_WAVE_COUNT_PAGES =10
-
-    #/* wave tx mode */
-
-    PI_WAVE_MODE_ONE_SHOT      =0
-    PI_WAVE_MODE_REPEAT        =1
-    PI_WAVE_MODE_ONE_SHOT_SYNC =2
-    PI_WAVE_MODE_REPEAT_SYNC   =3
-
-    #/* special wave at return values */
-
-    PI_WAVE_NOT_FOUND  =9998 #/* Transmitted wave not found. */
-    PI_NO_TX_WAVE      =9999 #/* No wave being transmitted. */
-
-    #/* Files, I2C, SPI, SER */
-
-    PI_FILE_SLOTS =16
-    PI_I2C_SLOTS  =64
-    PI_SPI_SLOTS  =32
-    PI_SER_SLOTS  =16
-
-    PI_MAX_I2C_ADDR =0x7F
-
-    PI_NUM_AUX_SPI_CHANNEL =3
-    PI_NUM_STD_SPI_CHANNEL =2
-
-    PI_MAX_I2C_DEVICE_COUNT =(1<<16)
-    PI_MAX_SPI_DEVICE_COUNT =(1<<16)
+    PI_MIN_WAVE_HALFSTOPBITS = 2
+    PI_MAX_WAVE_HALFSTOPBITS = 8
+
+    PI_WAVE_MAX_MICROS = (30 * 60 * 1000000) # /* half an hour */
+
+    PI_MAX_WAVES = 250
+
+    PI_MAX_WAVE_CYCLES = 65535
+    PI_MAX_WAVE_DELAY = 65535
+
+    PI_WAVE_COUNT_PAGES = 10
+
+    # /* wave tx mode */
+
+    PI_WAVE_MODE_ONE_SHOT = 0
+    PI_WAVE_MODE_REPEAT = 1
+    PI_WAVE_MODE_ONE_SHOT_SYNC = 2
+    PI_WAVE_MODE_REPEAT_SYNC = 3
+
+    # /* special wave at return values */
+
+    PI_WAVE_NOT_FOUND = 9998 # /* Transmitted wave not found. */
+    PI_NO_TX_WAVE = 9999 # /* No wave being transmitted. */
+
+    # /* Files, I2C, SPI, SER */
+
+    PI_FILE_SLOTS = 16
+    PI_I2C_SLOTS = 64
+    PI_SPI_SLOTS = 32
+    PI_SER_SLOTS = 16
+
+    PI_MAX_I2C_ADDR = 0x7F
+
+    PI_NUM_AUX_SPI_CHANNEL = 3
+    PI_NUM_STD_SPI_CHANNEL = 2
+
+    PI_MAX_I2C_DEVICE_COUNT = (1 << 16)
+    PI_MAX_SPI_DEVICE_COUNT = (1 << 16)
 
-    #/* max pi_i2c_msg_t per transaction */
+    # /* max pi_i2c_msg_t per transaction */
 
-    PI_I2C_RDRW_IOCTL_MAX_MSGS =42
+    PI_I2C_RDRW_IOCTL_MAX_MSGS = 42
 
-    #/* flags for i2cTransaction, pi_i2c_msg_t */
+    # /* flags for i2cTransaction, pi_i2c_msg_t */
 
-    PI_I2C_M_WR           =0x0000 #/* write data */
-    PI_I2C_M_RD           =0x0001 #/* read data */
-    PI_I2C_M_TEN          =0x0010 #/* ten bit chip address */
-    PI_I2C_M_RECV_LEN     =0x0400 #/* length will be first received byte */
-    PI_I2C_M_NO_RD_ACK    =0x0800 #/* if I2C_FUNC_PROTOCOL_MANGLING */
-    PI_I2C_M_IGNORE_NAK   =0x1000 #/* if I2C_FUNC_PROTOCOL_MANGLING */
-    PI_I2C_M_REV_DIR_ADDR =0x2000 #/* if I2C_FUNC_PROTOCOL_MANGLING */
-    PI_I2C_M_NOSTART      =0x4000 #/* if I2C_FUNC_PROTOCOL_MANGLING */
+    PI_I2C_M_WR = 0x0000 # /* write data */
+    PI_I2C_M_RD = 0x0001 # /* read data */
+    PI_I2C_M_TEN = 0x0010 # /* ten bit chip address */
+    PI_I2C_M_RECV_LEN = 0x0400 # /* length will be first received byte */
+    PI_I2C_M_NO_RD_ACK = 0x0800 # /* if I2C_FUNC_PROTOCOL_MANGLING */
+    PI_I2C_M_IGNORE_NAK = 0x1000 # /* if I2C_FUNC_PROTOCOL_MANGLING */
+    PI_I2C_M_REV_DIR_ADDR = 0x2000 # /* if I2C_FUNC_PROTOCOL_MANGLING */
+    PI_I2C_M_NOSTART = 0x4000 # /* if I2C_FUNC_PROTOCOL_MANGLING */
 
-    #/* bbI2CZip and i2cZip commands */
+    # /* bbI2CZip and i2cZip commands */
 
-    PI_I2C_END          =0
-    PI_I2C_ESC          =1
-    PI_I2C_START        =2
-    PI_I2C_COMBINED_ON  =2
-    PI_I2C_STOP         =3
-    PI_I2C_COMBINED_OFF =3
-    PI_I2C_ADDR         =4
-    PI_I2C_FLAGS        =5
-    PI_I2C_READ         =6
-    PI_I2C_WRITE        =7
+    PI_I2C_END = 0
+    PI_I2C_ESC = 1
+    PI_I2C_START = 2
+    PI_I2C_COMBINED_ON = 2
+    PI_I2C_STOP = 3
+    PI_I2C_COMBINED_OFF = 3
+    PI_I2C_ADDR = 4
+    PI_I2C_FLAGS = 5
+    PI_I2C_READ = 6
+    PI_I2C_WRITE = 7
 
-    #/* SPI */
+    # /* SPI */
 
-  #  PI_SPI_FLAGS_BITLEN(x) =((x&63)<<16)
-  #  PI_SPI_FLAGS_RX_LSB(x)  =((x&1)<<15)
-  #  PI_SPI_FLAGS_TX_LSB(x)  =((x&1)<<14)
-  #  PI_SPI_FLAGS_3WREN(x)  =((x&15)<<10)
-  #  PI_SPI_FLAGS_3WIRE(x)   =((x&1)<<9)
-  #  PI_SPI_FLAGS_AUX_SPI(x) =((x&1)<<8)
-  #  PI_SPI_FLAGS_RESVD(x)   =((x&7)<<5)
-  #  PI_SPI_FLAGS_CSPOLS(x)  =((x&7)<<2)
-  #  PI_SPI_FLAGS_MODE(x)    =((x&3))
+    #  PI_SPI_FLAGS_BITLEN(x) =((x&63)<<16)
+    #  PI_SPI_FLAGS_RX_LSB(x)  =((x&1)<<15)
+    #  PI_SPI_FLAGS_TX_LSB(x)  =((x&1)<<14)
+    #  PI_SPI_FLAGS_3WREN(x)  =((x&15)<<10)
+    #  PI_SPI_FLAGS_3WIRE(x)   =((x&1)<<9)
+    #  PI_SPI_FLAGS_AUX_SPI(x) =((x&1)<<8)
+    #  PI_SPI_FLAGS_RESVD(x)   =((x&7)<<5)
+    #  PI_SPI_FLAGS_CSPOLS(x)  =((x&7)<<2)
+    #  PI_SPI_FLAGS_MODE(x)    =((x&3))
 
-    #/* BSC registers */
+    # /* BSC registers */
 
-    BSC_DR         =0
-    BSC_RSR        =1
-    BSC_SLV        =2
-    BSC_CR         =3
-    BSC_FR         =4
-    BSC_IFLS       =5
-    BSC_IMSC       =6
-    BSC_RIS        =7
-    BSC_MIS        =8
-    BSC_ICR        =9
-    BSC_DMACR     =10
-    BSC_TDR       =11
-    BSC_GPUSTAT   =12
-    BSC_HCTRL     =13
-    BSC_DEBUG_I2C =14
-    BSC_DEBUG_SPI =15
+    BSC_DR = 0
+    BSC_RSR = 1
+    BSC_SLV = 2
+    BSC_CR = 3
+    BSC_FR = 4
+    BSC_IFLS = 5
+    BSC_IMSC = 6
+    BSC_RIS = 7
+    BSC_MIS = 8
+    BSC_ICR = 9
+    BSC_DMACR = 10
+    BSC_TDR = 11
+    BSC_GPUSTAT = 12
+    BSC_HCTRL = 13
+    BSC_DEBUG_I2C = 14
+    BSC_DEBUG_SPI = 15
 
-    BSC_CR_TESTFIFO =2048
-    BSC_CR_RXE  =512
-    BSC_CR_TXE  =256
-    BSC_CR_BRK  =128
-    BSC_CR_CPOL  =16
-    BSC_CR_CPHA   =8
-    BSC_CR_I2C    =4
-    BSC_CR_SPI    =2
-    BSC_CR_EN     =1
+    BSC_CR_TESTFIFO = 2048
+    BSC_CR_RXE = 512
+    BSC_CR_TXE = 256
+    BSC_CR_BRK = 128
+    BSC_CR_CPOL = 16
+    BSC_CR_CPHA = 8
+    BSC_CR_I2C = 4
+    BSC_CR_SPI = 2
+    BSC_CR_EN = 1
 
-    BSC_FR_RXBUSY =32
-    BSC_FR_TXFE   =16
-    BSC_FR_RXFF    =8
-    BSC_FR_TXFF    =4
-    BSC_FR_RXFE    =2
-    BSC_FR_TXBUSY  =1
+    BSC_FR_RXBUSY = 32
+    BSC_FR_TXFE = 16
+    BSC_FR_RXFF = 8
+    BSC_FR_TXFF = 4
+    BSC_FR_RXFE = 2
+    BSC_FR_TXBUSY = 1
 
-    #/* BSC GPIO */
+    # /* BSC GPIO */
 
-    BSC_SDA_MOSI =18
-    BSC_SCL_SCLK =19
-    BSC_MISO     =20
-    BSC_CE_N     =21
+    BSC_SDA_MOSI = 18
+    BSC_SCL_SCLK = 19
+    BSC_MISO = 20
+    BSC_CE_N = 21
 
-    #/* Longest busy delay */
+    # /* Longest busy delay */
 
-    PI_MAX_BUSY_DELAY =100
+    PI_MAX_BUSY_DELAY = 100
 
-    #/* timeout: 0-60000 */
+    # /* timeout: 0-60000 */
 
-    PI_MIN_WDOG_TIMEOUT =0
-    PI_MAX_WDOG_TIMEOUT =60000
+    PI_MIN_WDOG_TIMEOUT = 0
+    PI_MAX_WDOG_TIMEOUT = 60000
 
-    #/* timer: 0-9 */
+    # /* timer: 0-9 */
 
-    PI_MIN_TIMER =0
-    PI_MAX_TIMER =9
+    PI_MIN_TIMER = 0
+    PI_MAX_TIMER = 9
 
-    #/* millis: 10-60000 */
+    # /* millis: 10-60000 */
 
-    PI_MIN_MS =10
-    PI_MAX_MS =60000
+    PI_MIN_MS = 10
+    PI_MAX_MS = 60000
 
-    PI_MAX_SCRIPTS       =32
+    PI_MAX_SCRIPTS = 32
 
-    PI_MAX_SCRIPT_TAGS   =50
-    PI_MAX_SCRIPT_VARS  =150
-    PI_MAX_SCRIPT_PARAMS =10
+    PI_MAX_SCRIPT_TAGS = 50
+    PI_MAX_SCRIPT_VARS = 150
+    PI_MAX_SCRIPT_PARAMS = 10
 
-    #/* script status */
+    # /* script status */
 
-    PI_SCRIPT_INITING =0
-    PI_SCRIPT_HALTED  =1
-    PI_SCRIPT_RUNNING =2
-    PI_SCRIPT_WAITING =3
-    PI_SCRIPT_FAILED  =4
+    PI_SCRIPT_INITING = 0
+    PI_SCRIPT_HALTED = 1
+    PI_SCRIPT_RUNNING = 2
+    PI_SCRIPT_WAITING = 3
+    PI_SCRIPT_FAILED = 4
 
-    #/* signum: 0-63 */
+    # /* signum: 0-63 */
 
-    PI_MIN_SIGNUM =0
-    PI_MAX_SIGNUM =63
+    PI_MIN_SIGNUM = 0
+    PI_MAX_SIGNUM = 63
 
-    #/* timetype: 0-1 */
+    # /* timetype: 0-1 */
 
-    PI_TIME_RELATIVE =0
-    PI_TIME_ABSOLUTE =1
+    PI_TIME_RELATIVE = 0
+    PI_TIME_ABSOLUTE = 1
 
-    PI_MAX_MICS_DELAY =1000000 #/* 1 second */
-    PI_MAX_MILS_DELAY =60000   #/* 60 seconds */
+    PI_MAX_MICS_DELAY = 1000000 # /* 1 second */
+    PI_MAX_MILS_DELAY = 60000 # /* 60 seconds */
 
-    #/* cfgMillis */
+    # /* cfgMillis */
 
-    PI_BUF_MILLIS_MIN =100
-    PI_BUF_MILLIS_MAX =10000
+    PI_BUF_MILLIS_MIN = 100
+    PI_BUF_MILLIS_MAX = 10000
 
-    #/* cfgMicros: 1, 2, 4, 5, 8, or 10 */
+    # /* cfgMicros: 1, 2, 4, 5, 8, or 10 */
 
-    #/* cfgPeripheral: 0-1 */
+    # /* cfgPeripheral: 0-1 */
 
-    PI_CLOCK_PWM =0
-    PI_CLOCK_PCM =1
+    PI_CLOCK_PWM = 0
+    PI_CLOCK_PCM = 1
 
-    #/* DMA channel: 0-14 */
+    # /* DMA channel: 0-14 */
 
-    PI_MIN_DMA_CHANNEL =0
-    PI_MAX_DMA_CHANNEL =14
+    PI_MIN_DMA_CHANNEL = 0
+    PI_MAX_DMA_CHANNEL = 14
 
-    #/* port */
+    # /* port */
 
-    PI_MIN_SOCKET_PORT =1024
-    PI_MAX_SOCKET_PORT =32000
+    PI_MIN_SOCKET_PORT = 1024
+    PI_MAX_SOCKET_PORT = 32000
 
+    # /* ifFlags: */
 
-    #/* ifFlags: */
+    PI_DISABLE_FIFO_IF = 1
+    PI_DISABLE_SOCK_IF = 2
+    PI_LOCALHOST_SOCK_IF = 4
 
-    PI_DISABLE_FIFO_IF   =1
-    PI_DISABLE_SOCK_IF   =2
-    PI_LOCALHOST_SOCK_IF =4
+    # /* memAllocMode */
 
-    #/* memAllocMode */
+    PI_MEM_ALLOC_AUTO = 0
+    PI_MEM_ALLOC_PAGEMAP = 1
+    PI_MEM_ALLOC_MAILBOX = 2
 
-    PI_MEM_ALLOC_AUTO    =0
-    PI_MEM_ALLOC_PAGEMAP =1
-    PI_MEM_ALLOC_MAILBOX =2
+    # /* filters */
 
-    #/* filters */
+    PI_MAX_STEADY = 300000
+    PI_MAX_ACTIVE = 1000000
 
-    PI_MAX_STEADY  =300000
-    PI_MAX_ACTIVE =1000000
+    # /* gpioCfgInternals */
 
-    #/* gpioCfgInternals */
+    PI_CFG_DBG_LEVEL = 0 # /* bits 0-3 */
+    PI_CFG_ALERT_FREQ = 4 # /* bits 4-7 */
+    PI_CFG_RT_PRIORITY = (1 << 8)
+    PI_CFG_STATS = (1 << 9)
 
-    PI_CFG_DBG_LEVEL         =0 #/* bits 0-3 */
-    PI_CFG_ALERT_FREQ        =4 #/* bits 4-7 */
-    PI_CFG_RT_PRIORITY       =(1<<8)
-    PI_CFG_STATS             =(1<<9)
+    PI_CFG_ILLEGAL_VAL = (1 << 10)
 
-    PI_CFG_ILLEGAL_VAL       =(1<<10)
+    # /* gpioISR */
 
-    #/* gpioISR */
-
-    RISING_EDGE  =0
-    FALLING_EDGE =1
-    EITHER_EDGE  =2
-
-
-    #/* pads */
-
-    PI_MAX_PAD =2
-
-    PI_MIN_PAD_STRENGTH =1
-    PI_MAX_PAD_STRENGTH =16
-
-    #/* files */
-
-    PI_FILE_NONE   =0
-    PI_FILE_MIN    =1
-    PI_FILE_READ   =1
-    PI_FILE_WRITE  =2
-    PI_FILE_RW     =3
-    PI_FILE_APPEND =4
-    PI_FILE_CREATE =8
-    PI_FILE_TRUNC  =16
-    PI_FILE_MAX    =31
-
-    PI_FROM_START   =0
-    PI_FROM_CURRENT =1
-    PI_FROM_END     =2
-
-    #/* Allowed socket connect addresses */
-
-    MAX_CONNECT_ADDRESSES =256
-
-    #/* events */
-
-    PI_MAX_EVENT =31
-
-    #/* Event auto generated on BSC slave activity */
-
-    PI_EVENT_BSC =31
-
-
-    #/*DEF_S Socket Command Codes*/
-
-    PI_CMD_MODES  =0
-    PI_CMD_MODEG  =1
-    PI_CMD_PUD    =2
-    PI_CMD_READ   =3
-    PI_CMD_WRITE  =4
-    PI_CMD_PWM    =5
-    PI_CMD_PRS    =6
-    PI_CMD_PFS    =7
-    PI_CMD_SERVO  =8
-    PI_CMD_WDOG   =9
-    PI_CMD_BR1   =10
-    PI_CMD_BR2   =11
-    PI_CMD_BC1   =12
-    PI_CMD_BC2   =13
-    PI_CMD_BS1   =14
-    PI_CMD_BS2   =15
-    PI_CMD_TICK  =16
-    PI_CMD_HWVER =17
-    PI_CMD_NO    =18
-    PI_CMD_NB    =19
-    PI_CMD_NP    =20
-    PI_CMD_NC    =21
-    PI_CMD_PRG   =22
-    PI_CMD_PFG   =23
-    PI_CMD_PRRG  =24
-    PI_CMD_HELP  =25
-    PI_CMD_PIGPV =26
-    PI_CMD_WVCLR =27
-    PI_CMD_WVAG  =28
-    PI_CMD_WVAS  =29
-    PI_CMD_WVGO  =30
-    PI_CMD_WVGOR =31
-    PI_CMD_WVBSY =32
-    PI_CMD_WVHLT =33
-    PI_CMD_WVSM  =34
-    PI_CMD_WVSP  =35
-    PI_CMD_WVSC  =36
-    PI_CMD_TRIG  =37
-    PI_CMD_PROC  =38
-    PI_CMD_PROCD =39
-    PI_CMD_PROCR =40
-    PI_CMD_PROCS =41
-    PI_CMD_SLRO  =42
-    PI_CMD_SLR   =43
-    PI_CMD_SLRC  =44
-    PI_CMD_PROCP =45
-    PI_CMD_MICS  =46
-    PI_CMD_MILS  =47
-    PI_CMD_PARSE =48
-    PI_CMD_WVCRE =49
-    PI_CMD_WVDEL =50
-    PI_CMD_WVTX  =51
-    PI_CMD_WVTXR =52
-    PI_CMD_WVNEW =53
-
-    PI_CMD_I2CO  =54
-    PI_CMD_I2CC  =55
-    PI_CMD_I2CRD =56
-    PI_CMD_I2CWD =57
-    PI_CMD_I2CWQ =58
-    PI_CMD_I2CRS =59
-    PI_CMD_I2CWS =60
-    PI_CMD_I2CRB =61
-    PI_CMD_I2CWB =62
-    PI_CMD_I2CRW =63
-    PI_CMD_I2CWW =64
-    PI_CMD_I2CRK =65
-    PI_CMD_I2CWK =66
-    PI_CMD_I2CRI =67
-    PI_CMD_I2CWI =68
-    PI_CMD_I2CPC =69
-    PI_CMD_I2CPK =70
-
-    PI_CMD_SPIO  =71
-    PI_CMD_SPIC  =72
-    PI_CMD_SPIR  =73
-    PI_CMD_SPIW  =74
-    PI_CMD_SPIX  =75
-
-    PI_CMD_SERO  =76
-    PI_CMD_SERC  =77
-    PI_CMD_SERRB =78
-    PI_CMD_SERWB =79
-    PI_CMD_SERR  =80
-    PI_CMD_SERW  =81
-    PI_CMD_SERDA =82
-
-    PI_CMD_GDC   =83
-    PI_CMD_GPW   =84
-
-    PI_CMD_HC    =85
-    PI_CMD_HP    =86
-
-    PI_CMD_CF1   =87
-    PI_CMD_CF2   =88
-
-    PI_CMD_BI2CC =89
-    PI_CMD_BI2CO =90
-    PI_CMD_BI2CZ =91
-
-    PI_CMD_I2CZ  =92
-
-    PI_CMD_WVCHA =93
-
-    PI_CMD_SLRI  =94
-
-    PI_CMD_CGI   =95
-    PI_CMD_CSI   =96
-
-    PI_CMD_FG    =97
-    PI_CMD_FN    =98
-
-    PI_CMD_NOIB  =99
-
-    PI_CMD_WVTXM =100
-    PI_CMD_WVTAT =101
-
-    PI_CMD_PADS  =102
-    PI_CMD_PADG  =103
-
-    PI_CMD_FO    =104
-    PI_CMD_FC    =105
-    PI_CMD_FR    =106
-    PI_CMD_FW    =107
-    PI_CMD_FS    =108
-    PI_CMD_FL    =109
-
-    PI_CMD_SHELL =110
-
-    PI_CMD_BSPIC =111
-    PI_CMD_BSPIO =112
-    PI_CMD_BSPIX =113
-
-    PI_CMD_BSCX  =114
-
-    PI_CMD_EVM   =115
-    PI_CMD_EVT   =116
-
-    #/*DEF_E*/
-
-    #/* pseudo commands */
-
-    PI_CMD_SCRIPT =800
-
-    PI_CMD_ADD   =800
-    PI_CMD_AND   =801
-    PI_CMD_CALL  =802
-    PI_CMD_CMDR  =803
-    PI_CMD_CMDW  =804
-    PI_CMD_CMP   =805
-    PI_CMD_DCR   =806
-    PI_CMD_DCRA  =807
-    PI_CMD_DIV   =808
-    PI_CMD_HALT  =809
-    PI_CMD_INR   =810
-    PI_CMD_INRA  =811
-    PI_CMD_JM    =812
-    PI_CMD_JMP   =813
-    PI_CMD_JNZ   =814
-    PI_CMD_JP    =815
-    PI_CMD_JZ    =816
-    PI_CMD_TAG   =817
-    PI_CMD_LD    =818
-    PI_CMD_LDA   =819
-    PI_CMD_LDAB  =820
-    PI_CMD_MLT   =821
-    PI_CMD_MOD   =822
-    PI_CMD_NOP   =823
-    PI_CMD_OR    =824
-    PI_CMD_POP   =825
-    PI_CMD_POPA  =826
-    PI_CMD_PUSH  =827
-    PI_CMD_PUSHA =828
-    PI_CMD_RET   =829
-    PI_CMD_RL    =830
-    PI_CMD_RLA   =831
-    PI_CMD_RR    =832
-    PI_CMD_RRA   =833
-    PI_CMD_STA   =834
-    PI_CMD_STAB  =835
-    PI_CMD_SUB   =836
-    PI_CMD_SYS   =837
-    PI_CMD_WAIT  =838
-    PI_CMD_X     =839
-    PI_CMD_XA    =840
-    PI_CMD_XOR   =841
-    PI_CMD_EVTWT =842
-
-    #/*DEF_S Error Codes*/
-
-    PI_INIT_FAILED       =-1 #Error Code: gpioInitialise failed
-    PI_BAD_USER_GPIO     =-2 #Error Code: GPIO not 0-31
-    PI_BAD_GPIO          =-3 #Error Code: GPIO not 0-53
-    PI_BAD_MODE          =-4 #Error Code: mode not 0-7
-    PI_BAD_LEVEL         =-5 #Error Code: level not 0-1
-    PI_BAD_PUD           =-6 #Error Code: pud not 0-2
-    PI_BAD_PULSEWIDTH    =-7 #Error Code: pulsewidth not 0 or 500-2500
-    PI_BAD_DUTYCYCLE     =-8 #Error Code: dutycycle outside set range
-    PI_BAD_TIMER         =-9 #Error Code: timer not 0-9
-    PI_BAD_MS           =-10 #Error Code: ms not 10-60000
-    PI_BAD_TIMETYPE     =-11 #Error Code: timetype not 0-1
-    PI_BAD_SECONDS      =-12 #Error Code: seconds < 0
-    PI_BAD_MICROS       =-13 #Error Code: micros not 0-999999
-    PI_TIMER_FAILED     =-14 #Error Code: gpioSetTimerFunc failed
-    PI_BAD_WDOG_TIMEOUT =-15 #Error Code: timeout not 0-60000
-    PI_NO_ALERT_FUNC    =-16 #Error Code: DEPRECATED
-    PI_BAD_CLK_PERIPH   =-17 #Error Code: clock peripheral not 0-1
-    PI_BAD_CLK_SOURCE   =-18 #Error Code: DEPRECATED
-    PI_BAD_CLK_MICROS   =-19 #Error Code: clock micros not 1, 2, 4, 5, 8, or 10
-    PI_BAD_BUF_MILLIS   =-20 #Error Code: buf millis not 100-10000
-    PI_BAD_DUTYRANGE    =-21 #Error Code: dutycycle range not 25-40000
-    PI_BAD_DUTY_RANGE   =-21 #Error Code: DEPRECATED (use PI_BAD_DUTYRANGE)
-    PI_BAD_SIGNUM       =-22 #Error Code: signum not 0-63
-    PI_BAD_PATHNAME     =-23 #Error Code: can't open pathname
-    PI_NO_HANDLE        =-24 #Error Code: no handle available
-    PI_BAD_HANDLE       =-25 #Error Code: unknown handle
-    PI_BAD_IF_FLAGS     =-26 #Error Code: ifFlags > 3
-    PI_BAD_CHANNEL      =-27 #Error Code: DMA channel not 0-14
-    PI_BAD_PRIM_CHANNEL =-27 #Error Code: DMA primary channel not 0-14
-    PI_BAD_SOCKET_PORT  =-28 #Error Code: socket port not 1024-32000
-    PI_BAD_FIFO_COMMAND =-29 #Error Code: unrecognized fifo command
-    PI_BAD_SECO_CHANNEL =-30 #Error Code: DMA secondary channel not 0-6
-    PI_NOT_INITIALISED  =-31 #Error Code: function called before gpioInitialise
-    PI_INITIALISED      =-32 #Error Code: function called after gpioInitialise
-    PI_BAD_WAVE_MODE    =-33 #Error Code: waveform mode not 0-3
-    PI_BAD_CFG_INTERNAL =-34 #Error Code: bad parameter in gpioCfgInternals call
-    PI_BAD_WAVE_BAUD    =-35 #Error Code: baud rate not 50-250K(RX)/50-1M(TX)
-    PI_TOO_MANY_PULSES  =-36 #Error Code: waveform has too many pulses
-    PI_TOO_MANY_CHARS   =-37 #Error Code: waveform has too many chars
-    PI_NOT_SERIAL_GPIO  =-38 #Error Code: no bit bang serial read on GPIO
-    PI_BAD_SERIAL_STRUC =-39 #Error Code: bad (null) serial structure parameter
-    PI_BAD_SERIAL_BUF   =-40 #Error Code: bad (null) serial buf parameter
-    PI_NOT_PERMITTED    =-41 #Error Code: GPIO operation not permitted
-    PI_SOME_PERMITTED   =-42 #Error Code: one or more GPIO not permitted
-    PI_BAD_WVSC_COMMND  =-43 #Error Code: bad WVSC subcommand
-    PI_BAD_WVSM_COMMND  =-44 #Error Code: bad WVSM subcommand
-    PI_BAD_WVSP_COMMND  =-45 #Error Code: bad WVSP subcommand
-    PI_BAD_PULSELEN     =-46 #Error Code: trigger pulse length not 1-100
-    PI_BAD_SCRIPT       =-47 #Error Code: invalid script
-    PI_BAD_SCRIPT_ID    =-48 #Error Code: unknown script id
-    PI_BAD_SER_OFFSET   =-49 #Error Code: add serial data offset > 30 minutes
-    PI_GPIO_IN_USE      =-50 #Error Code: GPIO already in use
-    PI_BAD_SERIAL_COUNT =-51 #Error Code: must read at least a byte at a time
-    PI_BAD_PARAM_NUM    =-52 #Error Code: script parameter id not 0-9
-    PI_DUP_TAG          =-53 #Error Code: script has duplicate tag
-    PI_TOO_MANY_TAGS    =-54 #Error Code: script has too many tags
-    PI_BAD_SCRIPT_CMD   =-55 #Error Code: illegal script command
-    PI_BAD_VAR_NUM      =-56 #Error Code: script variable id not 0-149
-    PI_NO_SCRIPT_ROOM   =-57 #Error Code: no more room for scripts
-    PI_NO_MEMORY        =-58 #Error Code: can't allocate temporary memory
-    PI_SOCK_READ_FAILED =-59 #Error Code: socket read failed
-    PI_SOCK_WRIT_FAILED =-60 #Error Code: socket write failed
-    PI_TOO_MANY_PARAM   =-61 #Error Code: too many script parameters (> 10)
-    PI_NOT_HALTED       =-62 #Error Code: DEPRECATED
-    PI_SCRIPT_NOT_READY =-62 #Error Code: script initialising
-    PI_BAD_TAG          =-63 #Error Code: script has unresolved tag
-    PI_BAD_MICS_DELAY   =-64 #Error Code: bad MICS delay (too large)
-    PI_BAD_MILS_DELAY   =-65 #Error Code: bad MILS delay (too large)
-    PI_BAD_WAVE_ID      =-66 #Error Code: non existent wave id
-    PI_TOO_MANY_CBS     =-67 #Error Code: No more CBs for waveform
-    PI_TOO_MANY_OOL     =-68 #Error Code: No more OOL for waveform
-    PI_EMPTY_WAVEFORM   =-69 #Error Code: attempt to create an empty waveform
-    PI_NO_WAVEFORM_ID   =-70 #Error Code: no more waveforms
-    PI_I2C_OPEN_FAILED  =-71 #Error Code: can't open I2C device
-    PI_SER_OPEN_FAILED  =-72 #Error Code: can't open serial device
-    PI_SPI_OPEN_FAILED  =-73 #Error Code: can't open SPI device
-    PI_BAD_I2C_BUS      =-74 #Error Code: bad I2C bus
-    PI_BAD_I2C_ADDR     =-75 #Error Code: bad I2C address
-    PI_BAD_SPI_CHANNEL  =-76 #Error Code: bad SPI channel
-    PI_BAD_FLAGS        =-77 #Error Code: bad i2c/spi/ser open flags
-    PI_BAD_SPI_SPEED    =-78 #Error Code: bad SPI speed
-    PI_BAD_SER_DEVICE   =-79 #Error Code: bad serial device name
-    PI_BAD_SER_SPEED    =-80 #Error Code: bad serial baud rate
-    PI_BAD_PARAM        =-81 #Error Code: bad i2c/spi/ser parameter
-    PI_I2C_WRITE_FAILED =-82 #Error Code: i2c write failed
-    PI_I2C_READ_FAILED  =-83 #Error Code: i2c read failed
-    PI_BAD_SPI_COUNT    =-84 #Error Code: bad SPI count
-    PI_SER_WRITE_FAILED =-85 #Error Code: ser write failed
-    PI_SER_READ_FAILED  =-86 #Error Code: ser read failed
-    PI_SER_READ_NO_DATA =-87 #Error Code: ser read no data available
-    PI_UNKNOWN_COMMAND  =-88 #Error Code: unknown command
-    PI_SPI_XFER_FAILED  =-89 #Error Code: spi xfer/read/write failed
-    PI_BAD_POINTER      =-90 #Error Code: bad (NULL) pointer
-    PI_NO_AUX_SPI       =-91 #Error Code: no auxiliary SPI on Pi A or B
-    PI_NOT_PWM_GPIO     =-92 #Error Code: GPIO is not in use for PWM
-    PI_NOT_SERVO_GPIO   =-93 #Error Code: GPIO is not in use for servo pulses
-    PI_NOT_HCLK_GPIO    =-94 #Error Code: GPIO has no hardware clock
-    PI_NOT_HPWM_GPIO    =-95 #Error Code: GPIO has no hardware PWM
-    PI_BAD_HPWM_FREQ    =-96 #Error Code: hardware PWM frequency not 1-125M
-    PI_BAD_HPWM_DUTY    =-97 #Error Code: hardware PWM dutycycle not 0-1M
-    PI_BAD_HCLK_FREQ    =-98 #Error Code: hardware clock frequency not 4689-250M
-    PI_BAD_HCLK_PASS    =-99 #Error Code: need password to use hardware clock 1
-    PI_HPWM_ILLEGAL    =-100 #Error Code: illegal, PWM in use for main clock
-    PI_BAD_DATABITS    =-101 #Error Code: serial data bits not 1-32
-    PI_BAD_STOPBITS    =-102 #Error Code: serial (half) stop bits not 2-8
-    PI_MSG_TOOBIG      =-103 #Error Code: socket/pipe message too big
-    PI_BAD_MALLOC_MODE =-104 #Error Code: bad memory allocation mode
-    PI_TOO_MANY_SEGS   =-105 #Error Code: too many I2C transaction segments
-    PI_BAD_I2C_SEG     =-106 #Error Code: an I2C transaction segment failed
-    PI_BAD_SMBUS_CMD   =-107 #Error Code: SMBus command not supported by driver
-    PI_NOT_I2C_GPIO    =-108 #Error Code: no bit bang I2C in progress on GPIO
-    PI_BAD_I2C_WLEN    =-109 #Error Code: bad I2C write length
-    PI_BAD_I2C_RLEN    =-110 #Error Code: bad I2C read length
-    PI_BAD_I2C_CMD     =-111 #Error Code: bad I2C command
-    PI_BAD_I2C_BAUD    =-112 #Error Code: bad I2C baud rate, not 50-500k
-    PI_CHAIN_LOOP_CNT  =-113 #Error Code: bad chain loop count
-    PI_BAD_CHAIN_LOOP  =-114 #Error Code: empty chain loop
-    PI_CHAIN_COUNTER   =-115 #Error Code: too many chain counters
-    PI_BAD_CHAIN_CMD   =-116 #Error Code: bad chain command
-    PI_BAD_CHAIN_DELAY =-117 #Error Code: bad chain delay micros
-    PI_CHAIN_NESTING   =-118 #Error Code: chain counters nested too deeply
-    PI_CHAIN_TOO_BIG   =-119 #Error Code: chain is too long
-    PI_DEPRECATED      =-120 #Error Code: deprecated function removed
-    PI_BAD_SER_INVERT  =-121 #Error Code: bit bang serial invert not 0 or 1
-    PI_BAD_EDGE        =-122 #Error Code: bad ISR edge value, not 0-2
-    PI_BAD_ISR_INIT    =-123 #Error Code: bad ISR initialisation
-    PI_BAD_FOREVER     =-124 #Error Code: loop forever must be last command
-    PI_BAD_FILTER      =-125 #Error Code: bad filter parameter
-    PI_BAD_PAD         =-126 #Error Code: bad pad number
-    PI_BAD_STRENGTH    =-127 #Error Code: bad pad drive strength
-    PI_FIL_OPEN_FAILED =-128 #Error Code: file open failed
-    PI_BAD_FILE_MODE   =-129 #Error Code: bad file mode
-    PI_BAD_FILE_FLAG   =-130 #Error Code: bad file flag
-    PI_BAD_FILE_READ   =-131 #Error Code: bad file read
-    PI_BAD_FILE_WRITE  =-132 #Error Code: bad file write
-    PI_FILE_NOT_ROPEN  =-133 #Error Code: file not open for read
-    PI_FILE_NOT_WOPEN  =-134 #Error Code: file not open for write
-    PI_BAD_FILE_SEEK   =-135 #Error Code: bad file seek
-    PI_NO_FILE_MATCH   =-136 #Error Code: no files match pattern
-    PI_NO_FILE_ACCESS  =-137 #Error Code: no permission to access file
-    PI_FILE_IS_A_DIR   =-138 #Error Code: file is a directory
-    PI_BAD_SHELL_STATUS=-139 #Error Code: bad shell return status
-    PI_BAD_SCRIPT_NAME =-140 #Error Code: bad script name
-    PI_BAD_SPI_BAUD    =-141 #Error Code: bad SPI baud rate, not 50-500k
-    PI_NOT_SPI_GPIO    =-142 #Error Code: no bit bang SPI in progress on GPIO
-    PI_BAD_EVENT_ID    =-143 #Error Code: bad event id
-
-    PI_PIGIF_ERR_0    =-2000
-    PI_PIGIF_ERR_99   =-2099
-
-    PI_CUSTOM_ERR_0   =-3000
-    PI_CUSTOM_ERR_999 =-3999
-
-    #/*DEF_E*/
-
-    #/*DEF_S Defaults*/
-
-    PI_DEFAULT_BUFFER_MILLIS           =120
-    PI_DEFAULT_CLK_MICROS              =5
-    PI_DEFAULT_CLK_PERIPHERAL          =PI_CLOCK_PCM
-    PI_DEFAULT_IF_FLAGS                =0
-    PI_DEFAULT_FOREGROUND              =0
-    PI_DEFAULT_DMA_CHANNEL             =14
-    PI_DEFAULT_DMA_PRIMARY_CHANNEL     =14
-    PI_DEFAULT_DMA_SECONDARY_CHANNEL   =6
-    PI_DEFAULT_SOCKET_PORT             =8888
-    PI_DEFAULT_SOCKET_PORT_STR         ="8888"
-    PI_DEFAULT_SOCKET_ADDR_STR         ="127.0.0.1"
-    PI_DEFAULT_UPDATE_MASK_UNKNOWN     =0xFFFFFFFF
-    PI_DEFAULT_UPDATE_MASK_B1          =0x03E7CF93
-    PI_DEFAULT_UPDATE_MASK_A_B2        =0xFBC7CF9C
-    PI_DEFAULT_UPDATE_MASK_APLUS_BPLUS =0x0080480FFFFFFC
-    PI_DEFAULT_UPDATE_MASK_ZERO        =0x0080000FFFFFFC
-    PI_DEFAULT_UPDATE_MASK_PI2B        =0x0080480FFFFFFC
-    PI_DEFAULT_UPDATE_MASK_PI3B        =0x0000000FFFFFFC
-    PI_DEFAULT_UPDATE_MASK_COMPUTE     =0x00FFFFFFFFFFFF
-    PI_DEFAULT_MEM_ALLOC_MODE          =PI_MEM_ALLOC_AUTO
-
-    PI_DEFAULT_CFG_INTERNALS           =0
-
-    Pigif_bad_send           = -2000
-    Pigif_bad_recv           = -2001
-    Pigif_bad_getaddrinfo    = -2002
-    Pigif_bad_connect        = -2003
-    Pigif_bad_socket         = -2004
-    Pigif_bad_noib           = -2005
+    RISING_EDGE = 0
+    FALLING_EDGE = 1
+    EITHER_EDGE = 2
+
+    # /* pads */
+
+    PI_MAX_PAD = 2
+
+    PI_MIN_PAD_STRENGTH = 1
+    PI_MAX_PAD_STRENGTH = 16
+
+    # /* files */
+
+    PI_FILE_NONE = 0
+    PI_FILE_MIN = 1
+    PI_FILE_READ = 1
+    PI_FILE_WRITE = 2
+    PI_FILE_RW = 3
+    PI_FILE_APPEND = 4
+    PI_FILE_CREATE = 8
+    PI_FILE_TRUNC = 16
+    PI_FILE_MAX = 31
+
+    PI_FROM_START = 0
+    PI_FROM_CURRENT = 1
+    PI_FROM_END = 2
+
+    # /* Allowed socket connect addresses */
+
+    MAX_CONNECT_ADDRESSES = 256
+
+    # /* events */
+
+    PI_MAX_EVENT = 31
+
+    # /* Event auto generated on BSC slave activity */
+
+    PI_EVENT_BSC = 31
+
+    # /*DEF_S Socket Command Codes*/
+
+    PI_CMD_MODES = 0
+    PI_CMD_MODEG = 1
+    PI_CMD_PUD = 2
+    PI_CMD_READ = 3
+    PI_CMD_WRITE = 4
+    PI_CMD_PWM = 5
+    PI_CMD_PRS = 6
+    PI_CMD_PFS = 7
+    PI_CMD_SERVO = 8
+    PI_CMD_WDOG = 9
+    PI_CMD_BR1 = 10
+    PI_CMD_BR2 = 11
+    PI_CMD_BC1 = 12
+    PI_CMD_BC2 = 13
+    PI_CMD_BS1 = 14
+    PI_CMD_BS2 = 15
+    PI_CMD_TICK = 16
+    PI_CMD_HWVER = 17
+    PI_CMD_NO = 18
+    PI_CMD_NB = 19
+    PI_CMD_NP = 20
+    PI_CMD_NC = 21
+    PI_CMD_PRG = 22
+    PI_CMD_PFG = 23
+    PI_CMD_PRRG = 24
+    PI_CMD_HELP = 25
+    PI_CMD_PIGPV = 26
+    PI_CMD_WVCLR = 27
+    PI_CMD_WVAG = 28
+    PI_CMD_WVAS = 29
+    PI_CMD_WVGO = 30
+    PI_CMD_WVGOR = 31
+    PI_CMD_WVBSY = 32
+    PI_CMD_WVHLT = 33
+    PI_CMD_WVSM = 34
+    PI_CMD_WVSP = 35
+    PI_CMD_WVSC = 36
+    PI_CMD_TRIG = 37
+    PI_CMD_PROC = 38
+    PI_CMD_PROCD = 39
+    PI_CMD_PROCR = 40
+    PI_CMD_PROCS = 41
+    PI_CMD_SLRO = 42
+    PI_CMD_SLR = 43
+    PI_CMD_SLRC = 44
+    PI_CMD_PROCP = 45
+    PI_CMD_MICS = 46
+    PI_CMD_MILS = 47
+    PI_CMD_PARSE = 48
+    PI_CMD_WVCRE = 49
+    PI_CMD_WVDEL = 50
+    PI_CMD_WVTX = 51
+    PI_CMD_WVTXR = 52
+    PI_CMD_WVNEW = 53
+
+    PI_CMD_I2CO = 54
+    PI_CMD_I2CC = 55
+    PI_CMD_I2CRD = 56
+    PI_CMD_I2CWD = 57
+    PI_CMD_I2CWQ = 58
+    PI_CMD_I2CRS = 59
+    PI_CMD_I2CWS = 60
+    PI_CMD_I2CRB = 61
+    PI_CMD_I2CWB = 62
+    PI_CMD_I2CRW = 63
+    PI_CMD_I2CWW = 64
+    PI_CMD_I2CRK = 65
+    PI_CMD_I2CWK = 66
+    PI_CMD_I2CRI = 67
+    PI_CMD_I2CWI = 68
+    PI_CMD_I2CPC = 69
+    PI_CMD_I2CPK = 70
+
+    PI_CMD_SPIO = 71
+    PI_CMD_SPIC = 72
+    PI_CMD_SPIR = 73
+    PI_CMD_SPIW = 74
+    PI_CMD_SPIX = 75
+
+    PI_CMD_SERO = 76
+    PI_CMD_SERC = 77
+    PI_CMD_SERRB = 78
+    PI_CMD_SERWB = 79
+    PI_CMD_SERR = 80
+    PI_CMD_SERW = 81
+    PI_CMD_SERDA = 82
+
+    PI_CMD_GDC = 83
+    PI_CMD_GPW = 84
+
+    PI_CMD_HC = 85
+    PI_CMD_HP = 86
+
+    PI_CMD_CF1 = 87
+    PI_CMD_CF2 = 88
+
+    PI_CMD_BI2CC = 89
+    PI_CMD_BI2CO = 90
+    PI_CMD_BI2CZ = 91
+
+    PI_CMD_I2CZ = 92
+
+    PI_CMD_WVCHA = 93
+
+    PI_CMD_SLRI = 94
+
+    PI_CMD_CGI = 95
+    PI_CMD_CSI = 96
+
+    PI_CMD_FG = 97
+    PI_CMD_FN = 98
+
+    PI_CMD_NOIB = 99
+
+    PI_CMD_WVTXM = 100
+    PI_CMD_WVTAT = 101
+
+    PI_CMD_PADS = 102
+    PI_CMD_PADG = 103
+
+    PI_CMD_FO = 104
+    PI_CMD_FC = 105
+    PI_CMD_FR = 106
+    PI_CMD_FW = 107
+    PI_CMD_FS = 108
+    PI_CMD_FL = 109
+
+    PI_CMD_SHELL = 110
+
+    PI_CMD_BSPIC = 111
+    PI_CMD_BSPIO = 112
+    PI_CMD_BSPIX = 113
+
+    PI_CMD_BSCX = 114
+
+    PI_CMD_EVM = 115
+    PI_CMD_EVT = 116
+
+    # /*DEF_E*/
+
+    # /* pseudo commands */
+
+    PI_CMD_SCRIPT = 800
+
+    PI_CMD_ADD = 800
+    PI_CMD_AND = 801
+    PI_CMD_CALL = 802
+    PI_CMD_CMDR = 803
+    PI_CMD_CMDW = 804
+    PI_CMD_CMP = 805
+    PI_CMD_DCR = 806
+    PI_CMD_DCRA = 807
+    PI_CMD_DIV = 808
+    PI_CMD_HALT = 809
+    PI_CMD_INR = 810
+    PI_CMD_INRA = 811
+    PI_CMD_JM = 812
+    PI_CMD_JMP = 813
+    PI_CMD_JNZ = 814
+    PI_CMD_JP = 815
+    PI_CMD_JZ = 816
+    PI_CMD_TAG = 817
+    PI_CMD_LD = 818
+    PI_CMD_LDA = 819
+    PI_CMD_LDAB = 820
+    PI_CMD_MLT = 821
+    PI_CMD_MOD = 822
+    PI_CMD_NOP = 823
+    PI_CMD_OR = 824
+    PI_CMD_POP = 825
+    PI_CMD_POPA = 826
+    PI_CMD_PUSH = 827
+    PI_CMD_PUSHA = 828
+    PI_CMD_RET = 829
+    PI_CMD_RL = 830
+    PI_CMD_RLA = 831
+    PI_CMD_RR = 832
+    PI_CMD_RRA = 833
+    PI_CMD_STA = 834
+    PI_CMD_STAB = 835
+    PI_CMD_SUB = 836
+    PI_CMD_SYS = 837
+    PI_CMD_WAIT = 838
+    PI_CMD_X = 839
+    PI_CMD_XA = 840
+    PI_CMD_XOR = 841
+    PI_CMD_EVTWT = 842
+
+    # /*DEF_S Error Codes*/
+
+    PI_INIT_FAILED = -1 # Error Code: gpioInitialise failed
+    PI_BAD_USER_GPIO = -2 # Error Code: GPIO not 0-31
+    PI_BAD_GPIO = -3 # Error Code: GPIO not 0-53
+    PI_BAD_MODE = -4 # Error Code: mode not 0-7
+    PI_BAD_LEVEL = -5 # Error Code: level not 0-1
+    PI_BAD_PUD = -6 # Error Code: pud not 0-2
+    PI_BAD_PULSEWIDTH = -7 # Error Code: pulsewidth not 0 or 500-2500
+    PI_BAD_DUTYCYCLE = -8 # Error Code: dutycycle outside set range
+    PI_BAD_TIMER = -9 # Error Code: timer not 0-9
+    PI_BAD_MS = -10 # Error Code: ms not 10-60000
+    PI_BAD_TIMETYPE = -11 # Error Code: timetype not 0-1
+    PI_BAD_SECONDS = -12 # Error Code: seconds < 0
+    PI_BAD_MICROS = -13 # Error Code: micros not 0-999999
+    PI_TIMER_FAILED = -14 # Error Code: gpioSetTimerFunc failed
+    PI_BAD_WDOG_TIMEOUT = -15 # Error Code: timeout not 0-60000
+    PI_NO_ALERT_FUNC = -16 # Error Code: DEPRECATED
+    PI_BAD_CLK_PERIPH = -17 # Error Code: clock peripheral not 0-1
+    PI_BAD_CLK_SOURCE = -18 # Error Code: DEPRECATED
+    PI_BAD_CLK_MICROS = -19 # Error Code: clock micros not 1, 2, 4, 5, 8, or 10
+    PI_BAD_BUF_MILLIS = -20 # Error Code: buf millis not 100-10000
+    PI_BAD_DUTYRANGE = -21 # Error Code: dutycycle range not 25-40000
+    PI_BAD_DUTY_RANGE = -21 # Error Code: DEPRECATED (use PI_BAD_DUTYRANGE)
+    PI_BAD_SIGNUM = -22 # Error Code: signum not 0-63
+    PI_BAD_PATHNAME = -23 # Error Code: can't open pathname
+    PI_NO_HANDLE = -24 # Error Code: no handle available
+    PI_BAD_HANDLE = -25 # Error Code: unknown handle
+    PI_BAD_IF_FLAGS = -26 # Error Code: ifFlags > 3
+    PI_BAD_CHANNEL = -27 # Error Code: DMA channel not 0-14
+    PI_BAD_PRIM_CHANNEL = -27 # Error Code: DMA primary channel not 0-14
+    PI_BAD_SOCKET_PORT = -28 # Error Code: socket port not 1024-32000
+    PI_BAD_FIFO_COMMAND = -29 # Error Code: unrecognized fifo command
+    PI_BAD_SECO_CHANNEL = -30 # Error Code: DMA secondary channel not 0-6
+    PI_NOT_INITIALISED = -31 # Error Code: function called before gpioInitialise
+    PI_INITIALISED = -32 # Error Code: function called after gpioInitialise
+    PI_BAD_WAVE_MODE = -33 # Error Code: waveform mode not 0-3
+    PI_BAD_CFG_INTERNAL = -34 # Error Code: bad parameter in gpioCfgInternals call
+    PI_BAD_WAVE_BAUD = -35 # Error Code: baud rate not 50-250K(RX)/50-1M(TX)
+    PI_TOO_MANY_PULSES = -36 # Error Code: waveform has too many pulses
+    PI_TOO_MANY_CHARS = -37 # Error Code: waveform has too many chars
+    PI_NOT_SERIAL_GPIO = -38 # Error Code: no bit bang serial read on GPIO
+    PI_BAD_SERIAL_STRUC = -39 # Error Code: bad (null) serial structure parameter
+    PI_BAD_SERIAL_BUF = -40 # Error Code: bad (null) serial buf parameter
+    PI_NOT_PERMITTED = -41 # Error Code: GPIO operation not permitted
+    PI_SOME_PERMITTED = -42 # Error Code: one or more GPIO not permitted
+    PI_BAD_WVSC_COMMND = -43 # Error Code: bad WVSC subcommand
+    PI_BAD_WVSM_COMMND = -44 # Error Code: bad WVSM subcommand
+    PI_BAD_WVSP_COMMND = -45 # Error Code: bad WVSP subcommand
+    PI_BAD_PULSELEN = -46 # Error Code: trigger pulse length not 1-100
+    PI_BAD_SCRIPT = -47 # Error Code: invalid script
+    PI_BAD_SCRIPT_ID = -48 # Error Code: unknown script id
+    PI_BAD_SER_OFFSET = -49 # Error Code: add serial data offset > 30 minutes
+    PI_GPIO_IN_USE = -50 # Error Code: GPIO already in use
+    PI_BAD_SERIAL_COUNT = -51 # Error Code: must read at least a byte at a time
+    PI_BAD_PARAM_NUM = -52 # Error Code: script parameter id not 0-9
+    PI_DUP_TAG = -53 # Error Code: script has duplicate tag
+    PI_TOO_MANY_TAGS = -54 # Error Code: script has too many tags
+    PI_BAD_SCRIPT_CMD = -55 # Error Code: illegal script command
+    PI_BAD_VAR_NUM = -56 # Error Code: script variable id not 0-149
+    PI_NO_SCRIPT_ROOM = -57 # Error Code: no more room for scripts
+    PI_NO_MEMORY = -58 # Error Code: can't allocate temporary memory
+    PI_SOCK_READ_FAILED = -59 # Error Code: socket read failed
+    PI_SOCK_WRIT_FAILED = -60 # Error Code: socket write failed
+    PI_TOO_MANY_PARAM = -61 # Error Code: too many script parameters (> 10)
+    PI_NOT_HALTED = -62 # Error Code: DEPRECATED
+    PI_SCRIPT_NOT_READY = -62 # Error Code: script initialising
+    PI_BAD_TAG = -63 # Error Code: script has unresolved tag
+    PI_BAD_MICS_DELAY = -64 # Error Code: bad MICS delay (too large)
+    PI_BAD_MILS_DELAY = -65 # Error Code: bad MILS delay (too large)
+    PI_BAD_WAVE_ID = -66 # Error Code: non existent wave id
+    PI_TOO_MANY_CBS = -67 # Error Code: No more CBs for waveform
+    PI_TOO_MANY_OOL = -68 # Error Code: No more OOL for waveform
+    PI_EMPTY_WAVEFORM = -69 # Error Code: attempt to create an empty waveform
+    PI_NO_WAVEFORM_ID = -70 # Error Code: no more waveforms
+    PI_I2C_OPEN_FAILED = -71 # Error Code: can't open I2C device
+    PI_SER_OPEN_FAILED = -72 # Error Code: can't open serial device
+    PI_SPI_OPEN_FAILED = -73 # Error Code: can't open SPI device
+    PI_BAD_I2C_BUS = -74 # Error Code: bad I2C bus
+    PI_BAD_I2C_ADDR = -75 # Error Code: bad I2C address
+    PI_BAD_SPI_CHANNEL = -76 # Error Code: bad SPI channel
+    PI_BAD_FLAGS = -77 # Error Code: bad i2c/spi/ser open flags
+    PI_BAD_SPI_SPEED = -78 # Error Code: bad SPI speed
+    PI_BAD_SER_DEVICE = -79 # Error Code: bad serial device name
+    PI_BAD_SER_SPEED = -80 # Error Code: bad serial baud rate
+    PI_BAD_PARAM = -81 # Error Code: bad i2c/spi/ser parameter
+    PI_I2C_WRITE_FAILED = -82 # Error Code: i2c write failed
+    PI_I2C_READ_FAILED = -83 # Error Code: i2c read failed
+    PI_BAD_SPI_COUNT = -84 # Error Code: bad SPI count
+    PI_SER_WRITE_FAILED = -85 # Error Code: ser write failed
+    PI_SER_READ_FAILED = -86 # Error Code: ser read failed
+    PI_SER_READ_NO_DATA = -87 # Error Code: ser read no data available
+    PI_UNKNOWN_COMMAND = -88 # Error Code: unknown command
+    PI_SPI_XFER_FAILED = -89 # Error Code: spi xfer/read/write failed
+    PI_BAD_POINTER = -90 # Error Code: bad (NULL) pointer
+    PI_NO_AUX_SPI = -91 # Error Code: no auxiliary SPI on Pi A or B
+    PI_NOT_PWM_GPIO = -92 # Error Code: GPIO is not in use for PWM
+    PI_NOT_SERVO_GPIO = -93 # Error Code: GPIO is not in use for servo pulses
+    PI_NOT_HCLK_GPIO = -94 # Error Code: GPIO has no hardware clock
+    PI_NOT_HPWM_GPIO = -95 # Error Code: GPIO has no hardware PWM
+    PI_BAD_HPWM_FREQ = -96 # Error Code: hardware PWM frequency not 1-125M
+    PI_BAD_HPWM_DUTY = -97 # Error Code: hardware PWM dutycycle not 0-1M
+    PI_BAD_HCLK_FREQ = -98 # Error Code: hardware clock frequency not 4689-250M
+    PI_BAD_HCLK_PASS = -99 # Error Code: need password to use hardware clock 1
+    PI_HPWM_ILLEGAL = -100 # Error Code: illegal, PWM in use for main clock
+    PI_BAD_DATABITS = -101 # Error Code: serial data bits not 1-32
+    PI_BAD_STOPBITS = -102 # Error Code: serial (half) stop bits not 2-8
+    PI_MSG_TOOBIG = -103 # Error Code: socket/pipe message too big
+    PI_BAD_MALLOC_MODE = -104 # Error Code: bad memory allocation mode
+    PI_TOO_MANY_SEGS = -105 # Error Code: too many I2C transaction segments
+    PI_BAD_I2C_SEG = -106 # Error Code: an I2C transaction segment failed
+    PI_BAD_SMBUS_CMD = -107 # Error Code: SMBus command not supported by driver
+    PI_NOT_I2C_GPIO = -108 # Error Code: no bit bang I2C in progress on GPIO
+    PI_BAD_I2C_WLEN = -109 # Error Code: bad I2C write length
+    PI_BAD_I2C_RLEN = -110 # Error Code: bad I2C read length
+    PI_BAD_I2C_CMD = -111 # Error Code: bad I2C command
+    PI_BAD_I2C_BAUD = -112 # Error Code: bad I2C baud rate, not 50-500k
+    PI_CHAIN_LOOP_CNT = -113 # Error Code: bad chain loop count
+    PI_BAD_CHAIN_LOOP = -114 # Error Code: empty chain loop
+    PI_CHAIN_COUNTER = -115 # Error Code: too many chain counters
+    PI_BAD_CHAIN_CMD = -116 # Error Code: bad chain command
+    PI_BAD_CHAIN_DELAY = -117 # Error Code: bad chain delay micros
+    PI_CHAIN_NESTING = -118 # Error Code: chain counters nested too deeply
+    PI_CHAIN_TOO_BIG = -119 # Error Code: chain is too long
+    PI_DEPRECATED = -120 # Error Code: deprecated function removed
+    PI_BAD_SER_INVERT = -121 # Error Code: bit bang serial invert not 0 or 1
+    PI_BAD_EDGE = -122 # Error Code: bad ISR edge value, not 0-2
+    PI_BAD_ISR_INIT = -123 # Error Code: bad ISR initialisation
+    PI_BAD_FOREVER = -124 # Error Code: loop forever must be last command
+    PI_BAD_FILTER = -125 # Error Code: bad filter parameter
+    PI_BAD_PAD = -126 # Error Code: bad pad number
+    PI_BAD_STRENGTH = -127 # Error Code: bad pad drive strength
+    PI_FIL_OPEN_FAILED = -128 # Error Code: file open failed
+    PI_BAD_FILE_MODE = -129 # Error Code: bad file mode
+    PI_BAD_FILE_FLAG = -130 # Error Code: bad file flag
+    PI_BAD_FILE_READ = -131 # Error Code: bad file read
+    PI_BAD_FILE_WRITE = -132 # Error Code: bad file write
+    PI_FILE_NOT_ROPEN = -133 # Error Code: file not open for read
+    PI_FILE_NOT_WOPEN = -134 # Error Code: file not open for write
+    PI_BAD_FILE_SEEK = -135 # Error Code: bad file seek
+    PI_NO_FILE_MATCH = -136 # Error Code: no files match pattern
+    PI_NO_FILE_ACCESS = -137 # Error Code: no permission to access file
+    PI_FILE_IS_A_DIR = -138 # Error Code: file is a directory
+    PI_BAD_SHELL_STATUS = -139 # Error Code: bad shell return status
+    PI_BAD_SCRIPT_NAME = -140 # Error Code: bad script name
+    PI_BAD_SPI_BAUD = -141 # Error Code: bad SPI baud rate, not 50-500k
+    PI_NOT_SPI_GPIO = -142 # Error Code: no bit bang SPI in progress on GPIO
+    PI_BAD_EVENT_ID = -143 # Error Code: bad event id
+
+    PI_PIGIF_ERR_0 = -2000
+    PI_PIGIF_ERR_99 = -2099
+
+    PI_CUSTOM_ERR_0 = -3000
+    PI_CUSTOM_ERR_999 = -3999
+
+    # /*DEF_E*/
+
+    # /*DEF_S Defaults*/
+
+    PI_DEFAULT_BUFFER_MILLIS = 120
+    PI_DEFAULT_CLK_MICROS = 5
+    PI_DEFAULT_CLK_PERIPHERAL = PI_CLOCK_PCM
+    PI_DEFAULT_IF_FLAGS = 0
+    PI_DEFAULT_FOREGROUND = 0
+    PI_DEFAULT_DMA_CHANNEL = 14
+    PI_DEFAULT_DMA_PRIMARY_CHANNEL = 14
+    PI_DEFAULT_DMA_SECONDARY_CHANNEL = 6
+    PI_DEFAULT_SOCKET_PORT = 8888
+    PI_DEFAULT_SOCKET_PORT_STR = "8888"
+    PI_DEFAULT_SOCKET_ADDR_STR = "127.0.0.1"
+    PI_DEFAULT_UPDATE_MASK_UNKNOWN = 0xFFFFFFFF
+    PI_DEFAULT_UPDATE_MASK_B1 = 0x03E7CF93
+    PI_DEFAULT_UPDATE_MASK_A_B2 = 0xFBC7CF9C
+    PI_DEFAULT_UPDATE_MASK_APLUS_BPLUS = 0x0080480FFFFFFC
+    PI_DEFAULT_UPDATE_MASK_ZERO = 0x0080000FFFFFFC
+    PI_DEFAULT_UPDATE_MASK_PI2B = 0x0080480FFFFFFC
+    PI_DEFAULT_UPDATE_MASK_PI3B = 0x0000000FFFFFFC
+    PI_DEFAULT_UPDATE_MASK_COMPUTE = 0x00FFFFFFFFFFFF
+    PI_DEFAULT_MEM_ALLOC_MODE = PI_MEM_ALLOC_AUTO
+
+    PI_DEFAULT_CFG_INTERNALS = 0
+
+    Pigif_bad_send = -2000
+    Pigif_bad_recv = -2001
+    Pigif_bad_getaddrinfo = -2002
+    Pigif_bad_connect = -2003
+    Pigif_bad_socket = -2004
+    Pigif_bad_noib = -2005
     Pigif_duplicate_callback = -2006
-    Pigif_bad_malloc         = -2007
-    Pigif_bad_callback       = -2008
-    Pigif_notify_failed      = -2009
+    Pigif_bad_malloc = -2007
+    Pigif_bad_callback = -2008
+    Pigif_notify_failed = -2009
     Pigif_callback_not_found = -2010
-    Pigif_unconnected_pi     = -2011
-    Pigif_too_many_pis       = -2012
+    Pigif_unconnected_pi = -2011
+    Pigif_too_many_pis = -2012
   end
 end

--- a/lib/pigpio/gpio.rb
+++ b/lib/pigpio/gpio.rb
@@ -1,30 +1,37 @@
 class Pigpio
   class GPIO
-    attr_reader :pi,:gpio
-    def initialize(pi,gpio)
-      @pi=pi #0-15
-      @gpio=gpio #0-53
+    attr_reader :pi, :gpio
+    def initialize(pi, gpio)
+      @pi = pi # 0-15
+      @gpio = gpio # 0-53
     end
+
     def mode=(mode)
-      ret=IF.set_mode(@pi,@gpio,mode)
+      ret = IF.set_mode(@pi, @gpio, mode)
     end
+
     def mode
-      ret=IF.get_mode(@pi,@gpio)
+      ret = IF.get_mode(@pi, @gpio)
     end
+
     def pud=(pud)
-      ret=IF.set_pull_up_down(@pi,@gpio,pud)
+      ret = IF.set_pull_up_down(@pi, @gpio, pud)
     end
+
     def read
-      ret=IF.gpio_read(@pi,@gpio)
+      ret = IF.gpio_read(@pi, @gpio)
     end
+
     def write(level)
-      ret=IF.gpio_write(@pi,@gpio,level)
+      ret = IF.gpio_write(@pi, @gpio, level)
     end
+
     def hardware_clock(clkfreq)
-      ret=IF.hardware_clock(@pi,@gpio,clkfreq)
+      ret = IF.hardware_clock(@pi, @gpio, clkfreq)
     end
-    def hardware_PWM(vPWMfreq,vPWMduty)
-      ret=IF.hardware_PWM(@pi,@gpio,vPWMfreq,vPWMduty)
+
+    def hardware_PWM(vPWMfreq, vPWMduty)
+      ret = IF.hardware_PWM(@pi, @gpio, vPWMfreq, vPWMduty)
     end
   end
 end

--- a/lib/pigpio/i2c.rb
+++ b/lib/pigpio/i2c.rb
@@ -1,60 +1,77 @@
 class Pigpio
   class I2C
-    attr_reader :pi,:handle
-    def initialize(pi,i2c_bus,i2c_addr)
-      @pi=pi
-      @handle=IF.i2c_open(@pi,i2c_bus,i2c_addr,0)
+    attr_reader :pi, :handle
+    def initialize(pi, i2c_bus, i2c_addr)
+      @pi = pi
+      @handle = IF.i2c_open(@pi, i2c_bus, i2c_addr, 0)
     end
-    def close()
-      IF.i2c_close(@pi,@handle)
+
+    def close
+      IF.i2c_close(@pi, @handle)
     end
+
     def write_quick(bit)
-      IF.i2c_write_quick(@pi,@handle,bit)
+      IF.i2c_write_quick(@pi, @handle, bit)
     end
+
     def write_byte(bVal)
-      IF.i2c_write_byte(@pi,@handle,bVal)
+      IF.i2c_write_byte(@pi, @handle, bVal)
     end
-    def read_byte()
-      IF.i2c_read_byte(@pi,@handle)
+
+    def read_byte
+      IF.i2c_read_byte(@pi, @handle)
     end
-    def write_byte_data(i2c_reg,bVal)
-      IF.i2c_write_byte_data(@pi,@handle,i2c_reg,bVal)
+
+    def write_byte_data(i2c_reg, bVal)
+      IF.i2c_write_byte_data(@pi, @handle, i2c_reg, bVal)
     end
-    def write_word_data(i2c_reg,wVal)
-      IF.i2c_write_word_data(@pi,@handle,i2c_reg,wVal)
+
+    def write_word_data(i2c_reg, wVal)
+      IF.i2c_write_word_data(@pi, @handle, i2c_reg, wVal)
     end
+
     def read_byte_data(i2c_reg)
-      IF.i2c_read_byte_data(@pi,@handle,i2c_reg)
+      IF.i2c_read_byte_data(@pi, @handle, i2c_reg)
     end
+
     def read_word_data(i2c_reg)
-      IF.i2c_read_word_data(@pi,@handle,i2c_reg)
+      IF.i2c_read_word_data(@pi, @handle, i2c_reg)
     end
-    def process_call(i2c_reg,wVal)
-      IF.i2c_process_call(@pi,@handle,i2c_reg,wVal)
+
+    def process_call(i2c_reg, wVal)
+      IF.i2c_process_call(@pi, @handle, i2c_reg, wVal)
     end
+
     def read_block_data(i2c_reg)
-      IF.i2c_read_block_data(@pi,@handle,i2c_reg)
+      IF.i2c_read_block_data(@pi, @handle, i2c_reg)
     end
-    def read_i2c_block_data(i2c_reg,count)
-      IF.i2c_read_i2c_block_data(@pi,@handle,i2c_reg,count)
+
+    def read_i2c_block_data(i2c_reg, count)
+      IF.i2c_read_i2c_block_data(@pi, @handle, i2c_reg, count)
     end
-    def write_block_data(i2c_reg,buf)
-      IF.i2c_write_block_data(@pi,@handle,i2c_reg,buf)
+
+    def write_block_data(i2c_reg, buf)
+      IF.i2c_write_block_data(@pi, @handle, i2c_reg, buf)
     end
-    def write_i2c_block_data(i2c_reg,buf)
-      IF.i2c_write_i2c_block_data(@pi,@handle,i2c_reg,buf)
+
+    def write_i2c_block_data(i2c_reg, buf)
+      IF.i2c_write_i2c_block_data(@pi, @handle, i2c_reg, buf)
     end
-    def block_process_call(i2c_reg,buf)
-      IF.i2c_block_process_call(@pi,@handle,i2c_reg,buf)
+
+    def block_process_call(i2c_reg, buf)
+      IF.i2c_block_process_call(@pi, @handle, i2c_reg, buf)
     end
+
     def read_device(count)
-      IF.i2c_read_device(@pi,@handle,count)
+      IF.i2c_read_device(@pi, @handle, count)
     end
+
     def write_device(buf)
-      IF.i2c_write_device(@pi,@handle,buf)
+      IF.i2c_write_device(@pi, @handle, buf)
     end
-    def zip(inBuf,outLen)
-      IF.i2c_zip(@pi,@handle,inBuf,outLen)
+
+    def zip(inBuf, outLen)
+      IF.i2c_zip(@pi, @handle, inBuf, outLen)
     end
   end
 end

--- a/lib/pigpio/pwm.rb
+++ b/lib/pigpio/pwm.rb
@@ -1,38 +1,48 @@
 class Pigpio
   class PWM
-    def initialize(pi,gpio)
-      @pi=pi
-      @gpio=gpio
+    def initialize(pi, gpio)
+      @pi = pi
+      @gpio = gpio
     end
+
     def start(dutycycle)
-      ret=IF.set_PWM_dutycycle(@pi,@gpio,dutycycle)
+      ret = IF.set_PWM_dutycycle(@pi, @gpio, dutycycle)
     end
+
     def dutycycle=(dutycycle)
-      ret=IF.set_PWM_dutycycle(@pi,@gpio,dutycycle)
+      ret = IF.set_PWM_dutycycle(@pi, @gpio, dutycycle)
     end
+
     def dutycycle
-      ret=IF.get_PWM_dutycycle(@pi,@gpio)
+      ret = IF.get_PWM_dutycycle(@pi, @gpio)
     end
+
     def range=(range)
-      ret=IF.set_PWM_range(@pi,@gpio,range)
+      ret = IF.set_PWM_range(@pi, @gpio, range)
     end
+
     def range
-      ret=IF.get_PWM_range(@pi,@gpio)
+      ret = IF.get_PWM_range(@pi, @gpio)
     end
+
     def real_range
-      ret=IF.get_PWM_real_range(@pi,@gpio)
+      ret = IF.get_PWM_real_range(@pi, @gpio)
     end
+
     def frequency=(frequency)
-      ret=IF.set_PWM_frequency(@pi,@gpio,frequency)
+      ret = IF.set_PWM_frequency(@pi, @gpio, frequency)
     end
+
     def frequency
-      ret=IF.get_PWM_frequency(@pi,@gpio)
+      ret = IF.get_PWM_frequency(@pi, @gpio)
     end
+
     def servo_pulsewidth=(pulsewidth)
-      ret=IF.set_servo_pulsewidth(@pi,@gpio,pulsewidth)
+      ret = IF.set_servo_pulsewidth(@pi, @gpio, pulsewidth)
     end
+
     def servo_pulsewidth
-      ret=IF.get_servo_pulsewidth(@pi,@gpio)
+      ret = IF.get_servo_pulsewidth(@pi, @gpio)
     end
   end
 end

--- a/lib/pigpio/serial.rb
+++ b/lib/pigpio/serial.rb
@@ -1,29 +1,35 @@
 class Pigpio
   class Serial
-    attr_reader :pi,:handle
-    TTY=%w(/dev/tty /dev/serial)
-    Baud=[50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400]
-    def initialize(pi,ser_tty,baud)
-      @pi=pi
-      @handle=IF.serial_open(pi,ser_tty,baud=19200,0)
+    attr_reader :pi, :handle
+    TTY = %w[/dev/tty /dev/serial]
+    Baud = [50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600, 19200, 38400, 57600, 115200, 230400]
+    def initialize(pi, ser_tty, baud)
+      @pi = pi
+      @handle = IF.serial_open(pi, ser_tty, baud = 19200, 0)
     end
+
     def close
-      IF.serial_close(@pi,@handle)
+      IF.serial_close(@pi, @handle)
     end
+
     def byte=(bVal)
-      IF.serial_write_byte(@pi,@handle,bVal)
+      IF.serial_write_byte(@pi, @handle, bVal)
     end
+
     def byte
-      IF.serial_read_byte(@pi,@handle)
+      IF.serial_read_byte(@pi, @handle)
     end
+
     def write(buf)
-      IF.serial_write(@pi,@handle,buf)
+      IF.serial_write(@pi, @handle, buf)
     end
+
     def read(count)
-      IF.serial_read(@pi,@handle,count)
+      IF.serial_read(@pi, @handle, count)
     end
+
     def size
-      IF.serial_data_available(@pi,@handle)
+      IF.serial_data_available(@pi, @handle)
     end
   end
 end

--- a/lib/pigpio/spi.rb
+++ b/lib/pigpio/spi.rb
@@ -1,33 +1,37 @@
 class Pigpio
   class SPI
-    attr_reader :pi,:handle
-    def initialize(pi,spi_channel=0,enable_cex=1,baud=500000,bits_per_word: 8,first_MISO: false,first_MOSI: false,idol_bytes: 0,is_3wire: false,active_low_cex: 0,spi_mode: 0)
-      is_aux=(spi_channel!=0)
-      flg=((spi_mode.to_i      & 0x03      ) |
-         ((active_low_cex.to_i & 0x07 )<< 2) |
-         ((enable_cex.to_i     & 0x07 )<< 5) |
-         ((is_aux   ? 1 : 0) << 8) |
+    attr_reader :pi, :handle
+    def initialize(pi, spi_channel = 0, enable_cex = 1, baud = 500000, bits_per_word: 8, first_MISO: false, first_MOSI: false, idol_bytes: 0, is_3wire: false, active_low_cex: 0, spi_mode: 0)
+      is_aux = (spi_channel != 0)
+      flg = ((spi_mode.to_i & 0x03) |
+         ((active_low_cex.to_i & 0x07) << 2) |
+         ((enable_cex.to_i & 0x07) << 5) |
+         ((is_aux ? 1 : 0) << 8) |
          ((is_3wire ? 1 : 0) << 9) |
-         ((idol_bytes.to_i     & 0x0f )<< 10) |
+         ((idol_bytes.to_i & 0x0f) << 10) |
          ((first_MOSI ? 1 : 0) << 14) |
          ((first_MISO ? 1 : 0) << 15) |
-         ((bits_per_word.to_i  & 0x3f )<< 16)
-        )
-      @pi=pi
-      @byte_per_word=(bits_per_word/8.0).ceil
-      @handle=IF.spi_open(@pi,spi_channel,baud,flg)
+         ((bits_per_word.to_i & 0x3f) << 16)
+            )
+      @pi = pi
+      @byte_per_word = (bits_per_word / 8.0).ceil
+      @handle = IF.spi_open(@pi, spi_channel, baud, flg)
     end
+
     def close
-      IF.spi_close(@pi,@handle)
+      IF.spi_close(@pi, @handle)
     end
-    def read(words=1)
-      IF.spi_read(@pi,@handle,words*@byte_per_word)
+
+    def read(words = 1)
+      IF.spi_read(@pi, @handle, words * @byte_per_word)
     end
+
     def write(buf)
-      IF.spi_write(@pi,@handle,buf)
+      IF.spi_write(@pi, @handle, buf)
     end
+
     def xfer(buf)
-      IF.spi_xfer(@pi,@handle,buf)
+      IF.spi_xfer(@pi, @handle, buf)
     end
   end
 end

--- a/lib/pigpio/user_gpio.rb
+++ b/lib/pigpio/user_gpio.rb
@@ -2,26 +2,32 @@ require_relative "./gpio"
 class Pigpio
   class UserGPIO < GPIO
     def watchdog(timeout)
-      ret=IF.set_watchdog(@pi,@gpio,timeout)
+      ret = IF.set_watchdog(@pi, @gpio, timeout)
     end
+
     def glitch_filter(steady)
-      ret=IF.set_glitch_filter(@pi,@gpio,steady)
+      ret = IF.set_glitch_filter(@pi, @gpio, steady)
     end
-    def noise_filter(steady,active)
-      ret=IF.set_noise_filter(@pi,@gpio,steady,active)
+
+    def noise_filter(steady, active)
+      ret = IF.set_noise_filter(@pi, @gpio, steady, active)
     end
-    def callback(edge,&blk)
+
+    def callback(edge, &blk)
       return nil unless blk
-      IF.callback(@pi,@gpio,edge,&blk)
+      IF.callback(@pi, @gpio, edge, &blk)
     end
-    def wait_for_edge(edge,timeout)
-      ret=IF.wait_for_edge(@pi,@gpio,edge,timeout)
+
+    def wait_for_edge(edge, timeout)
+      ret = IF.wait_for_edge(@pi, @gpio, edge, timeout)
     end
-    def trigger(pulseLen,level)
-      ret=IF.gpio_trigger(@pi,@gpio,pulseLen,level)
+
+    def trigger(pulseLen, level)
+      ret = IF.gpio_trigger(@pi, @gpio, pulseLen, level)
     end
+
     def pwm
-      PWM.new(@pi,@gpio)
+      PWM.new(@pi, @gpio)
     end
   end
 end

--- a/lib/pigpio/wave.rb
+++ b/lib/pigpio/wave.rb
@@ -1,78 +1,100 @@
 class Pigpio
   class Wave
     def initialize(pi)
-      @pi=pi
+      @pi = pi
       IF.wave_clear(pi)
     end
+
     def clear
       IF.wave_clear(@pi)
     end
+
     def add_new
       IF.wave_add_new(@pi)
     end
+
     def add_generic(pulses)
-      IF.wave_add_generic(@pi,pulses)
+      IF.wave_add_generic(@pi, pulses)
     end
-    def add_serial(user_gpio,baud,data_bits,stop_bits,offset,str)
-      IF.wave_add_serial(@pi,user_gpio,baud,data_bits,stop_bits,offset,str)
+
+    def add_serial(user_gpio, baud, data_bits, stop_bits, offset, str)
+      IF.wave_add_serial(@pi, user_gpio, baud, data_bits, stop_bits, offset, str)
     end
+
     def create
       IF.wave_create(@pi)
     end
+
     def delete(id)
-      IF.wave_delete(@pi,id)
+      IF.wave_delete(@pi, id)
     end
+
     def send_once(id)
-      IF.wave_delete(@pi,id)
+      IF.wave_delete(@pi, id)
     end
+
     def send_repeat(id)
-      IF.wave_delete(@pi,id)
+      IF.wave_delete(@pi, id)
     end
-    def send_using_mode(id,mode)
-      IF.wave_delete(@pi,id,mode)
+
+    def send_using_mode(id, mode)
+      IF.wave_delete(@pi, id, mode)
     end
+
     def chain(buf)
-      IF.wave_chain(@pi,buf)
+      IF.wave_chain(@pi, buf)
     end
+
     def tx_at
       IF.wave_tx_at(@pi)
     end
+
     def tx_busy
       IF.wave_tx_busy(@pi)
     end
+
     def tx_stop
       IF.wave_tx_stop(@pi)
     end
+
     def micros
       IF.wave_get_micros(@pi)
     end
+
     def high_micros
       IF.wave_get_high_micros(@pi)
     end
+
     def max_micros
       IF.wave_get_max_micros(@pi)
     end
+
     def pulses
       IF.wave_get_pulses(@pi)
     end
+
     def high_pulses
       IF.wave_get_high_pulses(@pi)
     end
+
     def max_pulses
       IF.wave_get_max_pulses(@pi)
     end
+
     def cbs
       IF.wave_get_cbs(@pi)
     end
+
     def high_cbs
       IF.wave_get_high_cbs(@pi)
     end
+
     def max_cbs
       IF.wave_get_max_cbs(@pi)
     end
-    def pulse(on,off,us)
-      Pulse.make(on,off,us)
+
+    def pulse(on, off, us)
+      Pulse.make(on, off, us)
     end
-        
   end
 end

--- a/pigpio.gemspec
+++ b/pigpio.gemspec
@@ -1,24 +1,23 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "pigpio/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "pigpio"
-  spec.version       = Pigpio::VERSION
-  spec.authors       = ["nak1114"]
-  spec.email         = ["naktak1114@gmail.com"]
+  spec.name = "pigpio"
+  spec.version = Pigpio::VERSION
+  spec.authors = ["nak1114"]
+  spec.email = ["naktak1114@gmail.com"]
 
-  spec.summary       = %q{This gem is a ruby binding to a pigpio library.}
-  spec.description   = %q{This gem is a ruby binding to a pigpio library.}
-  spec.homepage      = "http://www.github.com/nak1114/ruby-extension-pigpio"
-  spec.license       = "MIT"
-  spec.extensions    = %w(ext/pigpio/extconf.rb)
+  spec.summary = "This gem is a ruby binding to a pigpio library."
+  spec.description = "This gem is a ruby binding to a pigpio library."
+  spec.homepage = "http://www.github.com/nak1114/ruby-extension-pigpio"
+  spec.license = "MIT"
+  spec.extensions = %w[ext/pigpio/extconf.rb]
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-#    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    #    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 
     spec.metadata["homepage_uri"] = spec.homepage
     spec.metadata["source_code_uri"] = spec.homepage
@@ -30,17 +29,17 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(docs|example|test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["ext","lib"]
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["ext", "lib"]
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = ">= 2.0.0"
   spec.add_development_dependency "bundler", "> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake-compiler", "~> 1.0"
-  
+  spec.add_development_dependency "standard"
 end

--- a/spec/ext/extconf.rb
+++ b/spec/ext/extconf.rb
@@ -1,4 +1,4 @@
-require 'mkmf'
-$defs << "-DVFILENAME=\\\"#{File.expand_path('../values.txt', __FILE__)}\\\""
-$defs << "-DAFILENAME=\\\"#{File.expand_path('../args.txt', __FILE__)}\\\""
-create_makefile('libpigpiod_if2')
+require "mkmf"
+$defs << "-DVFILENAME=\\\"#{File.expand_path("../values.txt", __FILE__)}\\\""
+$defs << "-DAFILENAME=\\\"#{File.expand_path("../args.txt", __FILE__)}\\\""
+create_makefile("libpigpiod_if2")

--- a/spec/gpio_spec.rb
+++ b/spec/gpio_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Pigpio::GPIO do
   before do
     Pigpio::IF.time_time
   end
-  let(:pin){Pigpio.new.gpio(32)}
+  let(:pin) { Pigpio.new.gpio(32) }
   it "#gpio" do
     skip
   end

--- a/spec/pigpio_spec.rb
+++ b/spec/pigpio_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Pigpio do
     read_args
     expect(Pigpio::VERSION).not_to be nil
   end
-  let(:pi){Pigpio.new}
-
+  let(:pi) { Pigpio.new }
 
   it "start and stop with success" do
     write_seq "1"
@@ -61,5 +60,4 @@ RSpec.describe Pigpio::IF do
   it "time_time" do
     expect(Pigpio::IF.time_time).to be 12.3
   end
-
 end

--- a/spec/pwm_spec.rb
+++ b/spec/pwm_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Pigpio::PWM do
   before do
     Pigpio::IF.time_time
   end
-  let(:pin){Pigpio.new.gpio(0)}
+  let(:pin) { Pigpio.new.gpio(0) }
   it "#dutycycle=" do
     skip
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,20 +12,21 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.filter_run :focus => true
+  config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end
 
-SeqFile=File.expand_path('../ext/values.txt', __FILE__)
-ArgsFile=File.expand_path('../ext/args.txt', __FILE__)
-def write_seq(str,writefile=true)
-  File.write(SeqFile,str.chomp)
+SeqFile = File.expand_path("../ext/values.txt", __FILE__)
+ArgsFile = File.expand_path("../ext/args.txt", __FILE__)
+def write_seq(str, writefile = true)
+  File.write(SeqFile, str.chomp)
   read_args if writefile
 end
-def read_args()
-  ret=nil
+
+def read_args
+  ret = nil
   if File.exist? ArgsFile
-    ret=File.read(ArgsFile)
+    ret = File.read(ArgsFile)
     FileUtils.rm(ArgsFile)
   end
   ret

--- a/spec/user_gpio_spec.rb
+++ b/spec/user_gpio_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Pigpio::UserGPIO do
   before do
     Pigpio::IF.time_time
   end
-  let(:pin){Pigpio.new.gpio(0)}
+  let(:pin) { Pigpio.new.gpio(0) }
   it "#watchdog" do
     skip
   end
@@ -14,10 +14,10 @@ RSpec.describe Pigpio::UserGPIO do
   end
   it "#callback" do
     write_seq "1"
-    cb=nil
+    cb = nil
     begin
-      ary=[]
-      cb=pin.callback(Pigpio::Constant::RISING_EDGE){|tick,level| ary << [tick,level]}
+      ary = []
+      cb = pin.callback(Pigpio::Constant::RISING_EDGE) { |tick, level| ary << [tick, level] }
       expect(cb.id).to be 123
       sleep 3
     rescue e
@@ -26,7 +26,7 @@ RSpec.describe Pigpio::UserGPIO do
       cb.cancel
     end
     expect(ary).to eq [[88, 99], [87, 98]]
-    expect(cb.id).to be -1
+    expect(cb.id).to be(-1)
   end
   it "#wait_for_edge" do
     skip

--- a/spec/wave_spec.rb
+++ b/spec/wave_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Pigpio::Wave do
   before do
     Pigpio::IF.time_time
   end
-  let(:wave){Pigpio.new.wave()}
+  let(:wave) { Pigpio.new.wave }
   it "#new" do
     skip
   end
@@ -35,7 +35,7 @@ RSpec.describe Pigpio::Wave do
   end
   it "#chain" do
     write_seq "1"
-    wave.chain([255,0,1,255,1,3,0,2])
+    wave.chain([255, 0, 1, 255, 1, 3, 0, 2])
     expect(read_args).to eq "pigpio_start : (null),(null)\nwave_chain : 8 : ffffffff 0 1 ffffffff 1 3 0 2\n"
   end
   it "#tx_at" do


### PR DESCRIPTION
The formatting of the code (things like missing new lines between methods) made the source difficult to read.

How about adopting [standard](https://github.com/testdouble/standard)?

This PR adds the standard gem as a development dependency, fixes all the auto-correctable errors, and ignores the rest for now.