### PR TITLE
Fix wave send once, repeat and using mode

### DIFF
--- a/lib/pigpio/wave.rb
+++ b/lib/pigpio/wave.rb
@@ -30,15 +30,15 @@ class Pigpio
     end
 
     def send_once(id)
-      IF.wave_delete(@pi, id)
+      IF.wave_send_once(@pi, id)
     end
 
     def send_repeat(id)
-      IF.wave_delete(@pi, id)
+      IF.wave_send_repeat(@pi, id)
     end
 
     def send_using_mode(id, mode)
-      IF.wave_delete(@pi, id, mode)
+      IF.wave_send_using_mode(@pi, id, mode)
     end
 
     def chain(buf)


### PR DESCRIPTION
All 3 of these were calling wave_delete instead of their respective C functions.